### PR TITLE
set the hikari version to ==dev120

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ packages = [{ include = "crescent" }]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-hikari = ">=2.0.0.dev120"
+hikari = "==2.0.0.dev120"
 sigparse = "^3.0.0"
 floodgate-rs = { version = "^0.1.1", optional = true }
 types-croniter = { version = "==1.0.11", optional = true }


### PR DESCRIPTION
This will prevent future hikari versions, e.g. dev121, from introducing breaking changes that cause this crescent version to break.