### PR TITLE
feat!: v2

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,0 @@
-version: "2"
-checks:
-  argument-count:
-    enabled: false

--- a/README.md
+++ b/README.md
@@ -48,11 +48,12 @@ in over 17k servers.
 ## Usage
 Crescent uses [class commands](https://github.com/hikari-crescent/hikari-crescent/blob/main/examples/basic/basic.py)
 to simplify creating commands. Class commands allow you to create a command similar to how you declare a
-dataclass. The option function takes a type followed by the description, then optional information.
+dataclass. Options are declared with builder objects from `crescent.options`.
 
 ```python
 import crescent
 import hikari
+from crescent import options
 
 bot = hikari.GatewayBot("YOUR_TOKEN")
 client = crescent.Client(bot)
@@ -62,7 +63,7 @@ client = crescent.Client(bot)
 # Create a slash command
 @crescent.command(name="say")
 class Say:
-    word = crescent.option(str, "The word to say")
+    word = options.string("The word to say")
 
     async def callback(self, ctx: crescent.Context) -> None:
         await ctx.respond(self.word)
@@ -80,19 +81,18 @@ async def ping(ctx: crescent.Context):
     await ctx.respond("Pong!")
 ```
 
-### Typing to Option Types Lookup Table 
-| Type | Option Type |
+### Option Builders Lookup Table
+| Builder | Option Type |
 |---|---|
-| `str` | Text |
-| `int` | Integer |
-| `bool` | Boolean |
-| `float` | Number |
-| `hikari.User` | User |
-| `hikari.Role` | Role |
-| `crescent.Mentionable` | Role or User |
-| Any Hikari channel type. | Channel. The options will be the channel type and its subclasses. |
-| `List[Channel Types]` | Channel. ^ |
-| `hikari.Attachment` | Attachment |
+| `options.string(...)` | Text |
+| `options.number(...)` | Integer |
+| `options.boolean(...)` | Boolean |
+| `options.floating(...)` | Number |
+| `options.user(...)` | User |
+| `options.role(...)` | Role |
+| `options.mentionable(...)` | Role or User |
+| `options.channel(...)` | Channel. Use `.channel_types([...])` to restrict channel kinds. |
+| `options.attachment(...)` | Attachment |
 
 
 ### Autocomplete
@@ -101,6 +101,8 @@ value is the option name and the second value is the option value. `str`, `int`,
 can be used.
 
 ```python
+from crescent import options
+
 async def autocomplete(
     ctx: crescent.AutocompleteContext, option: hikari.AutocompleteInteractionOption
 ) -> list[tuple[str, str]]:
@@ -109,9 +111,9 @@ async def autocomplete(
 @client.include
 @crescent.command(name="class-command")
 class ClassCommand:
-    option = crescent.option(str, autocomplete=autocomplete)
+    option = options.string("Choose a value").autocomplete(autocomplete)
 
-    async def callback(self) -> None:
+    async def callback(self, ctx: crescent.Context) -> None:
         await ctx.respond(self.option)
 ```
 

--- a/crescent/__init__.py
+++ b/crescent/__init__.py
@@ -19,7 +19,7 @@ __all__: Sequence[str] = (
     "command",
     "user_command",
     "message_command",
-    "option",
+    "options",
     "hook",
     "HookResult",
     "Group",

--- a/crescent/__init__.py
+++ b/crescent/__init__.py
@@ -1,52 +1,67 @@
-from importlib.metadata import version
-from typing import Sequence
+from __future__ import annotations
 
-from crescent.client import *
-from crescent.commands import *
-from crescent.context import *
-from crescent.errors import *
-from crescent.events import *
-from crescent.exceptions import *
-from crescent.hooks import *
-from crescent.locale import *
-from crescent.mentionable import *
-from crescent.plugin import *
-from crescent.typedefs import *
+from importlib.metadata import version
+
+from crescent.client import Client, GatewayTraits, RESTTraits
+from crescent.commands import Group, SubGroup, command, message_command, options, user_command
+from crescent.context import AutocompleteContext, Context
+from crescent.errors import catch_autocomplete, catch_command, catch_event
+from crescent.events import event
+from crescent.exceptions import (
+    AlreadyRegisteredError,
+    ConverterExceptionMeta,
+    ConverterExceptions,
+    CrescentException,
+    PermissionsError,
+    PluginAlreadyLoadedError,
+)
+from crescent.hooks import HookResult, hook
+from crescent.locale import LocaleBuilder
+from crescent.mentionable import Mentionable
+from crescent.plugin import Plugin, PluginManager
+from crescent.typedefs import (
+    AutocompleteCallbackT,
+    ClassCommandProto,
+    CommandCallbackT,
+    CommandHookCallbackT,
+    CommandOptionsT,
+    OptionTypesT,
+)
 
 __version__: str = version("hikari-crescent")
 
-__all__: Sequence[str] = (
-    "command",
-    "user_command",
-    "message_command",
-    "options",
-    "hook",
-    "HookResult",
-    "Group",
-    "SubGroup",
-    "Client",
-    "GatewayTraits",
-    "RESTTraits",
-    "Context",
-    "AutocompleteContext",
-    "catch_command",
-    "catch_event",
-    "catch_autocomplete",
-    "event",
-    "CrescentException",
-    "ConverterExceptions",
-    "ConverterExceptionMeta",
+__all__ = (
     "AlreadyRegisteredError",
-    "PluginAlreadyLoadedError",
-    "PermissionsError",
+    "AutocompleteCallbackT",
+    "AutocompleteContext",
+    "ClassCommandProto",
+    "Client",
+    "CommandCallbackT",
+    "CommandHookCallbackT",
+    "CommandOptionsT",
+    "Context",
+    "ConverterExceptionMeta",
+    "ConverterExceptions",
+    "CrescentException",
+    "GatewayTraits",
+    "Group",
+    "HookResult",
     "LocaleBuilder",
     "Mentionable",
-    "CommandCallbackT",
-    "CommandOptionsT",
     "OptionTypesT",
-    "CommandHookCallbackT",
-    "AutocompleteCallbackT",
-    "ClassCommandProto",
+    "PermissionsError",
     "Plugin",
+    "PluginAlreadyLoadedError",
     "PluginManager",
+    "RESTTraits",
+    "SubGroup",
+    "catch_autocomplete",
+    "catch_command",
+    "catch_event",
+    "command",
+    "event",
+    "hook",
+    "message_command",
+    "options",
+    "user_command",
 )

--- a/crescent/_about.py
+++ b/crescent/_about.py
@@ -1,6 +1,6 @@
-from typing import Sequence
+from __future__ import annotations
 
-__all__: Sequence[str] = ("__maintainer__", "__copyright__", "__license__")
+__all__ = ("__copyright__", "__license__", "__maintainer__")
 
 __maintainer__ = "Lunarmagpie"
 __copyright__ = "© 2021-present Lunarmagpie"

--- a/crescent/client.py
+++ b/crescent/client.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
-from asyncio import get_running_loop
+import logging
+from asyncio import Future, get_running_loop
 from contextlib import suppress
 from functools import partial
 from itertools import chain
-from traceback import print_exception
-from typing import TYPE_CHECKING, Protocol, overload, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar, overload, runtime_checkable
 
-from hikari import AutocompleteInteraction, AutocompleteInteractionOption, CommandInteraction
-from hikari import Event as hk_Event
 from hikari import (
+    AutocompleteInteraction,
+    AutocompleteInteractionOption,
+    CommandInteraction,
     InteractionCreateEvent,
     InteractionServerAware,
     PartialInteraction,
@@ -17,34 +18,37 @@ from hikari import (
     Snowflakeish,
     StartedEvent,
 )
+from hikari import Event as hk_Event
 from hikari.traits import EventManagerAware, RESTAware
 
 from crescent.hooks import add_hooks
 from crescent.internal.handle_resp import handle_resp
-from crescent.internal.includable import Includable
 from crescent.internal.registry import CommandHandler, ErrorHandler
 from crescent.plugin import PluginManager
-from crescent.typedefs import EventHookCallbackT
 from crescent.utils import create_task
 
 if TYPE_CHECKING:
-    from asyncio import Future
-    from typing import Any, Awaitable, Callable, Coroutine, Sequence, TypeVar
+    from collections.abc import Awaitable, Callable, Coroutine, Sequence
 
     from hikari.api import InteractionResponseBuilder
 
     from crescent.context import AutocompleteContext, Context
+    from crescent.internal.includable import Includable
     from crescent.typedefs import (
         AutocompleteErrorHandlerCallbackT,
         CommandErrorHandlerCallbackT,
         CommandHookCallbackT,
         EventErrorHandlerCallbackT,
+        EventHookCallbackT,
     )
 
     INCLUDABLE = TypeVar("INCLUDABLE", bound=Includable[Any])
 
 
-__all__: Sequence[str] = ("Client", "GatewayTraits", "RESTTraits")
+__all__ = ("Client", "GatewayTraits", "RESTTraits")
+
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 @runtime_checkable
@@ -94,7 +98,7 @@ class Client:
         command_after_hooks: list[CommandHookCallbackT] | None = None,
         event_hooks: list[EventHookCallbackT[hk_Event]] | None = None,
         event_after_hooks: list[EventHookCallbackT[hk_Event]] | None = None,
-    ):
+    ) -> None:
         """
         Args:
             app:
@@ -179,16 +183,17 @@ class Client:
             app.event_manager.subscribe(InteractionCreateEvent, self._on_interaction_event)
             return
         app.interaction_server.set_listener(
-            CommandInteraction,  # pyright: ignore
-            self._on_rest_interaction,  # type: ignore
+            CommandInteraction,
+            self._on_rest_interaction,  # type: ignore[arg-type]
         )
         app.interaction_server.set_listener(
-            AutocompleteInteraction,  # type: ignore
-            self._on_rest_interaction,  # type: ignore
+            AutocompleteInteraction,  # type: ignore[arg-type]
+            self._on_rest_interaction,  # type: ignore[arg-type]
         )
 
     async def _on_rest_interaction(
-        self, interaction: PartialInteraction
+        self,
+        interaction: PartialInteraction,
     ) -> InteractionResponseBuilder:
         future: Future[InteractionResponseBuilder] = get_running_loop().create_future()
         create_task(handle_resp(self, interaction, future))
@@ -207,7 +212,8 @@ class Client:
     def include(self, obj: None = ...) -> Callable[[INCLUDABLE], INCLUDABLE]: ...
 
     def include(
-        self, obj: INCLUDABLE | None = None
+        self,
+        obj: INCLUDABLE | None = None,
     ) -> INCLUDABLE | Callable[[INCLUDABLE], INCLUDABLE]:
         """
         Register an includable object, such as an event or command handler.
@@ -256,7 +262,11 @@ class Client:
         return self._command_handler
 
     async def on_crescent_command_error(
-        self, exc: Exception, ctx: Context, was_handled: bool
+        self,
+        exc: Exception,
+        ctx: Context,
+        was_handled: bool,  # noqa: FBT001
+        /,
     ) -> None:
         """
         This function is run when there is an error in a crescent command
@@ -267,11 +277,18 @@ class Client:
             return
         with suppress(Exception):
             await ctx.respond("An unexpected error occurred.", ephemeral=True)
-        print(f"Unhandled exception occurred in the command {ctx.command}:")
-        print_exception(exc.__class__, exc, exc.__traceback__)
+        logger.error(
+            "Unhandled exception occurred in the command %s",
+            ctx.command,
+            exc_info=exc,
+        )
 
     async def on_crescent_event_error(
-        self, exc: Exception, event: hk_Event, was_handled: bool
+        self,
+        exc: Exception,
+        event: hk_Event,
+        was_handled: bool,  # noqa: FBT001
+        /,
     ) -> None:
         """
         This function is run when there is an error in a crescent event
@@ -280,15 +297,19 @@ class Client:
         """
         if was_handled:
             return
-        print(f"Unhandled exception occurred for {type(event)}:")
-        print_exception(exc.__class__, exc, exc.__traceback__)
+        logger.error(
+            "Unhandled exception occurred for %s",
+            type(event),
+            exc_info=exc,
+        )
 
     async def on_crescent_autocomplete_error(
         self,
         exc: Exception,
         ctx: AutocompleteContext,
         option: AutocompleteInteractionOption,
-        was_handled: bool,
+        was_handled: bool,  # noqa: FBT001
+        /,
     ) -> None:
         """
         This function is run when there is an error in an autocomplete handler
@@ -297,11 +318,12 @@ class Client:
         """
         if was_handled:
             return
-        print(
-            f"Unhandled exception occurred in the autocomplete interaction for {ctx.command}"
-            f" (option: {option.name}):"
+        logger.error(
+            "Unhandled exception occurred in the autocomplete interaction for %s (option: %s)",
+            ctx.command,
+            option.name,
+            exc_info=exc,
         )
-        print_exception(exc.__class__, exc, exc.__traceback__)
 
     def _run_future(self, callback: Coroutine[Any, Any, Any]) -> None:
         if self._started:
@@ -313,7 +335,8 @@ class Client:
         self._started = True
 
     def _add_startup_callback(
-        self, callback: Callable[[], Awaitable[None]]
+        self,
+        callback: Callable[[], Awaitable[None]],
     ) -> Callable[[], None] | None:
         async def on_start(_: Any) -> None:
             await callback()
@@ -321,7 +344,7 @@ class Client:
         if isinstance(self.app, GatewayTraits):
             self.app.event_manager.subscribe(StartedEvent, on_start)
             return partial(self.app.event_manager.unsubscribe, StartedEvent, on_start)
-        elif isinstance(self.app, RESTBotAware):
+        if isinstance(self.app, RESTBotAware):
             self.app.add_startup_callback(on_start)
             return partial(self.app.remove_startup_callback, on_start)
         return None

--- a/crescent/commands/__init__.py
+++ b/crescent/commands/__init__.py
@@ -1,8 +1,9 @@
 from typing import Sequence
 
 from crescent.commands.decorators import *
+from crescent.commands import options
+from crescent.commands.options import ClassCommandOption
 from crescent.commands.groups import *
-from crescent.commands.options import *
 
 __all__: Sequence[str] = (
     "command",
@@ -11,5 +12,5 @@ __all__: Sequence[str] = (
     "Group",
     "SubGroup",
     "ClassCommandOption",
-    "option",
+    "options",
 )

--- a/crescent/commands/__init__.py
+++ b/crescent/commands/__init__.py
@@ -1,16 +1,16 @@
-from typing import Sequence
+from __future__ import annotations
 
-from crescent.commands.decorators import *
 from crescent.commands import options
+from crescent.commands.decorators import command, message_command, user_command
+from crescent.commands.groups import Group, SubGroup
 from crescent.commands.options import ClassCommandOption
-from crescent.commands.groups import *
 
-__all__: Sequence[str] = (
-    "command",
-    "user_command",
-    "message_command",
+__all__ = (
+    "ClassCommandOption",
     "Group",
     "SubGroup",
-    "ClassCommandOption",
+    "command",
+    "message_command",
     "options",
+    "user_command",
 )

--- a/crescent/commands/decorators.py
+++ b/crescent/commands/decorators.py
@@ -16,7 +16,7 @@ from hikari import (
     UndefinedType,
 )
 
-from crescent.commands.options import ClassCommandOption
+from crescent.commands.options import ClassCommandOption, Marker
 from crescent.exceptions import ConverterExceptionMeta, ConverterExceptions
 from crescent.internal.registry import register_command
 from crescent.locale import LocaleBuilder
@@ -190,21 +190,21 @@ def command(
                 continue
 
             if TYPE_CHECKING:
-                v = cast("ClassCommandOption[Any, Any]", v)  # type: ignore[redundant-cast]
+                v = cast("ClassCommandOption[Marker, Any, Any, Any]", v)
 
             generated = v._gen_option(n)
             options.append(generated)
 
-            if v.autocomplete:
-                autocomplete[generated.name] = v.autocomplete
+            if v._autocomplete:
+                autocomplete[generated.name] = v._autocomplete
 
-            if v.converter:
-                converters[generated.name] = v.converter
+            if v._converter:
+                converters[generated.name] = v._converter
 
             if generated.name != n:
                 name_map[generated.name] = n
 
-            defaults[generated.name] = v.default
+            defaults[generated.name] = v._default
 
         callback_func = _class_command_callback(callback, defaults, name_map, converters)
 

--- a/crescent/commands/decorators.py
+++ b/crescent/commands/decorators.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from asyncio import Task, create_task
 from functools import partial, wraps
 from inspect import isawaitable, isclass, isfunction
-from typing import TYPE_CHECKING, Awaitable, Callable, Iterable, cast, overload
+from typing import TYPE_CHECKING, Any, cast, overload
 
 from hikari import (
     UNDEFINED,
@@ -19,13 +19,13 @@ from hikari import (
 from crescent.commands.options import ClassCommandOption, Marker
 from crescent.exceptions import ConverterExceptionMeta, ConverterExceptions
 from crescent.internal.registry import register_command
-from crescent.locale import LocaleBuilder
 
 if TYPE_CHECKING:
-    from typing import Any, Sequence, TypeVar
+    from collections.abc import Awaitable, Callable, Iterable
 
     from crescent.internal.app_command import AppCommandMeta
     from crescent.internal.includable import Includable
+    from crescent.locale import LocaleBuilder
     from crescent.typedefs import (
         AutocompleteCallbackT,
         ClassCommandProto,
@@ -34,9 +34,7 @@ if TYPE_CHECKING:
         UserCommandCallbackT,
     )
 
-    T = TypeVar("T")
-
-__all__: Sequence[str] = ("command", "user_command", "message_command")
+__all__ = ("command", "message_command", "user_command")
 
 
 def _class_command_callback(
@@ -80,10 +78,11 @@ def _class_command_callback(
 
             tasks.append((create_task(set_later(key, val)), key, raw_val))
 
+        # TODO: can we gather these tasks?
         for t, key, raw_val in tasks:
             try:
                 await t
-            except Exception as e:
+            except Exception as e:  # noqa: PERF203
                 errors.append(ConverterExceptionMeta(cls, key, raw_val, e))
 
         if errors:
@@ -96,7 +95,8 @@ def _class_command_callback(
 
 @overload
 def command(
-    callback: CommandCallbackT | type[ClassCommandProto], /
+    callback: CommandCallbackT | type[ClassCommandProto],
+    /,
 ) -> Includable[AppCommandMeta]: ...
 
 
@@ -171,7 +171,7 @@ def command(
             default_member_permissions=default_member_permissions,
             context_types=context_types,
             nsfw=nsfw,
-        )  # pyright: ignore
+        )  # pyright: ignore[reportReturnType]
 
     autocomplete: dict[str, AutocompleteCallbackT[Any]] = {}
     options: list[CommandOption] = []
@@ -305,7 +305,7 @@ def user_command(
             default_member_permissions=default_member_permissions,
             context_types=context_types,
             nsfw=nsfw,
-        )  # pyright: ignore
+        )  # pyright: ignore[reportReturnType]
 
     return register_command(
         callback=_kwargs_to_args_callback(callback),
@@ -386,7 +386,7 @@ def message_command(
             default_member_permissions=default_member_permissions,
             context_types=context_types,
             nsfw=nsfw,
-        )  # pyright: ignore
+        )  # pyright: ignore[reportReturnType]
 
     return register_command(
         callback=_kwargs_to_args_callback(callback),

--- a/crescent/commands/groups.py
+++ b/crescent/commands/groups.py
@@ -1,21 +1,21 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
 
 from hikari import UNDEFINED, ApplicationContextType, Permissions, UndefinedType
 
 from crescent.exceptions import PermissionsError
 
 if TYPE_CHECKING:
-    from typing import Sequence
+    from collections.abc import Iterable
 
     from crescent.internal.app_command import AppCommandMeta
     from crescent.internal.includable import Includable
     from crescent.locale import LocaleBuilder
     from crescent.typedefs import CommandHookCallbackT
 
-__all__: Sequence[str] = ("Group", "SubGroup")
+__all__ = ("Group", "SubGroup")
 
 
 def _check_permissions(includable: Includable[AppCommandMeta]) -> None:
@@ -23,7 +23,7 @@ def _check_permissions(includable: Includable[AppCommandMeta]) -> None:
     if includable.metadata.app_command.default_member_permissions:
         raise PermissionsError(
             "`default_member_permissions` cannot be declared for subcommands."
-            " Permissions must be declared in the `crescent.Group` object."
+            " Permissions must be declared in the `crescent.Group` object.",
         )
 
 

--- a/crescent/commands/options.py
+++ b/crescent/commands/options.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import Any, Awaitable, Callable, Generic, Sequence, TypeVar, cast, overload
-from typing_extensions import Never, Self
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, overload
 
 from hikari import (
     UNDEFINED,
@@ -14,37 +13,41 @@ from hikari import (
     CommandOption,
     InteractionChannel,
     OptionType,
-    PartialChannel,
     Role,
     UndefinedOr,
     User,
 )
+from typing_extensions import Never, Self
 
 from crescent.locale import LocaleBuilder, str_or_build_locale
-from crescent.mentionable import Mentionable
-from crescent.typedefs import AutocompleteCallbackT
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Sequence
+
+    from crescent.mentionable import Mentionable
+    from crescent.typedefs import AutocompleteCallbackT
 
 __all__ = (
-    "Marker",
-    "StrMarker",
-    "BoolMarker",
-    "IntMarker",
-    "FloatMarker",
-    "ChannelMarker",
-    "RoleMarker",
-    "UserMarker",
-    "MentionableMarker",
     "AttachmentMarker",
+    "BoolMarker",
+    "ChannelMarker",
     "ClassCommandOption",
-    "string",
-    "boolean",
-    "number",
-    "floating",
-    "channel",
-    "role",
-    "user",
-    "mentionable",
+    "FloatMarker",
+    "IntMarker",
+    "Marker",
+    "MentionableMarker",
+    "RoleMarker",
+    "StrMarker",
+    "UserMarker",
     "attachment",
+    "boolean",
+    "channel",
+    "floating",
+    "mentionable",
+    "number",
+    "role",
+    "string",
+    "user",
 )
 
 
@@ -66,7 +69,6 @@ MarkT = TypeVar("MarkT", bound=Marker)
 InT = TypeVar("InT")
 ConverterT = TypeVar("ConverterT")
 DefaultT = TypeVar("DefaultT")
-ChannelTypeT = TypeVar("ChannelTypeT", bound=PartialChannel)
 T = TypeVar("T")
 
 
@@ -112,7 +114,7 @@ class ClassCommandOption(Generic[MarkT, InT, ConverterT, DefaultT]):
         """Set the Discord-facing name for this option."""
         return replace(self, _name=name)
 
-    def default(self, default: T) -> "ClassCommandOption[MarkT, InT, ConverterT, T]":
+    def default(self, default: T) -> ClassCommandOption[MarkT, InT, ConverterT, T]:
         """Set a default value, making this option optional."""
         return replace(
             cast("ClassCommandOption[MarkT, InT, ConverterT, T]", self),
@@ -120,8 +122,9 @@ class ClassCommandOption(Generic[MarkT, InT, ConverterT, DefaultT]):
         )
 
     def convert(
-        self, converter: Callable[[InT], T | Awaitable[T]]
-    ) -> "ClassCommandOption[MarkT, InT, T, DefaultT]":
+        self,
+        converter: Callable[[InT], T | Awaitable[T]],
+    ) -> ClassCommandOption[MarkT, InT, T, DefaultT]:
         """Convert the raw option value before assigning it to the command instance."""
         return replace(
             cast("ClassCommandOption[MarkT, InT, T, DefaultT]", self),
@@ -129,27 +132,27 @@ class ClassCommandOption(Generic[MarkT, InT, ConverterT, DefaultT]):
         )
 
     def channel_types(
-        self: "ClassCommandOption[ChannelMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[ChannelMarker, InT, ConverterT, DefaultT],
         types: Sequence[ChannelType],
-    ) -> "ClassCommandOption[ChannelMarker, InT, ConverterT, DefaultT]":
+    ) -> ClassCommandOption[ChannelMarker, InT, ConverterT, DefaultT]:
         """Restrict which Discord channel types may be selected for this option."""
         return replace(self, _channel_types=types)
 
     @overload
     def autocomplete(
-        self: "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[IntMarker, InT, ConverterT, DefaultT],
         autocomplete: AutocompleteCallbackT[int],
-    ) -> "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]": ...
+    ) -> ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]: ...
     @overload
     def autocomplete(
-        self: "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT],
         autocomplete: AutocompleteCallbackT[float],
-    ) -> "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]": ...
+    ) -> ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]: ...
     @overload
     def autocomplete(
-        self: "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[StrMarker, InT, ConverterT, DefaultT],
         autocomplete: AutocompleteCallbackT[str],
-    ) -> "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]": ...
+    ) -> ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]: ...
 
     def autocomplete(self, autocomplete: AutocompleteCallbackT[Any]) -> Any:
         """Attach an autocomplete callback to this option."""
@@ -157,69 +160,70 @@ class ClassCommandOption(Generic[MarkT, InT, ConverterT, DefaultT]):
 
     @overload
     def choices(
-        self: "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[IntMarker, InT, ConverterT, DefaultT],
         choices: Sequence[tuple[str | LocaleBuilder, int] | CommandChoice],
-    ) -> "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]": ...
+    ) -> ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]: ...
     @overload
     def choices(
-        self: "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT],
         choices: Sequence[tuple[str | LocaleBuilder, float] | CommandChoice],
-    ) -> "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]": ...
+    ) -> ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]: ...
     @overload
     def choices(
-        self: "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[StrMarker, InT, ConverterT, DefaultT],
         choices: Sequence[tuple[str | LocaleBuilder, str] | CommandChoice],
-    ) -> "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]": ...
+    ) -> ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]: ...
 
     def choices(
-        self, choices: Sequence[tuple[str | LocaleBuilder, int | str | float] | CommandChoice]
+        self,
+        choices: Sequence[tuple[str | LocaleBuilder, int | str | float] | CommandChoice],
     ) -> Any:
         """Set the fixed choices users may select for this option."""
         return replace(self, _choices=_build_choices(choices))
 
     @overload
     def min_value(
-        self: "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[IntMarker, InT, ConverterT, DefaultT],
         value: int,
-    ) -> "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]": ...
+    ) -> ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]: ...
 
     @overload
     def min_value(
-        self: "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT],
         value: float,
-    ) -> "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]": ...
+    ) -> ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]: ...
 
-    def min_value(self, value: int | float) -> Any:
+    def min_value(self, value: float) -> Any:
         """Set the inclusive minimum numeric value for this option."""
         return replace(self, _min_value=value)
 
     @overload
     def max_value(
-        self: "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[IntMarker, InT, ConverterT, DefaultT],
         value: int,
-    ) -> "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]": ...
+    ) -> ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]: ...
 
     @overload
     def max_value(
-        self: "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT],
         value: float,
-    ) -> "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]": ...
+    ) -> ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]: ...
 
-    def max_value(self, value: int | float) -> Any:
+    def max_value(self, value: float) -> Any:
         """Set the inclusive maximum numeric value for this option."""
         return replace(self, _max_value=value)
 
     def min_length(
-        self: "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[StrMarker, InT, ConverterT, DefaultT],
         value: int,
-    ) -> "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]":
+    ) -> ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]:
         """Set the inclusive minimum string length for this option."""
         return replace(self, _min_length=value)
 
     def max_length(
-        self: "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[StrMarker, InT, ConverterT, DefaultT],
         value: int,
-    ) -> "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]":
+    ) -> ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]:
         """Set the inclusive maximum string length for this option."""
         return replace(self, _max_length=value)
 
@@ -228,19 +232,27 @@ class ClassCommandOption(Generic[MarkT, InT, ConverterT, DefaultT]):
 
     @overload
     def __get__(
-        self: "ClassCommandOption[MarkT, InT, Never, Never]", inst: object, cls: Any
+        self: ClassCommandOption[MarkT, InT, Never, Never],
+        inst: object,
+        cls: Any,
     ) -> InT: ...
     @overload
     def __get__(
-        self: "ClassCommandOption[MarkT, InT, ConverterT, Never]", inst: object, cls: Any
+        self: ClassCommandOption[MarkT, InT, ConverterT, Never],
+        inst: object,
+        cls: Any,
     ) -> ConverterT: ...
     @overload
     def __get__(
-        self: "ClassCommandOption[MarkT, InT, Never, DefaultT]", inst: object, cls: Any
+        self: ClassCommandOption[MarkT, InT, Never, DefaultT],
+        inst: object,
+        cls: Any,
     ) -> InT | DefaultT: ...
     @overload
     def __get__(
-        self: "ClassCommandOption[MarkT, InT, ConverterT, DefaultT]", inst: object, cls: Any
+        self: ClassCommandOption[MarkT, InT, ConverterT, DefaultT],
+        inst: object,
+        cls: Any,
     ) -> ConverterT | DefaultT: ...
 
     def __get__(self, inst: Any | None, cls: Any) -> Any:
@@ -278,7 +290,8 @@ class _OptionBuilder(Generic[MarkT, InT]):
     _type: OptionType
 
     def __call__(
-        self, description: str | LocaleBuilder
+        self,
+        description: str | LocaleBuilder,
     ) -> ClassCommandOption[MarkT, InT, Never, Never]:
         """Create an option declaration with the provided description."""
         return ClassCommandOption(_description=description, _type=self._type)
@@ -292,6 +305,6 @@ channel: _OptionBuilder[ChannelMarker, InteractionChannel] = _OptionBuilder(Opti
 role: _OptionBuilder[RoleMarker, Role] = _OptionBuilder(OptionType.ROLE)
 user: _OptionBuilder[UserMarker, User] = _OptionBuilder(OptionType.USER)
 mentionable: _OptionBuilder[MentionableMarker, Mentionable] = _OptionBuilder(
-    OptionType.MENTIONABLE
+    OptionType.MENTIONABLE,
 )
 attachment: _OptionBuilder[AttachmentMarker, Attachment] = _OptionBuilder(OptionType.ATTACHMENT)

--- a/crescent/commands/options.py
+++ b/crescent/commands/options.py
@@ -1,18 +1,10 @@
+"""Builder-based option declarations for class commands."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Awaitable,
-    Callable,
-    Generic,
-    Sequence,
-    TypeVar,
-    Union,
-    cast,
-    overload,
-)
+from typing import Any, Awaitable, Callable, Generic, Sequence, TypeVar, cast, overload
+from typing_extensions import Never, Self
 
 from hikari import (
     UNDEFINED,
@@ -20,153 +12,236 @@ from hikari import (
     ChannelType,
     CommandChoice,
     CommandOption,
-    DMChannel,
-    GroupDMChannel,
-    GuildCategory,
-    GuildForumChannel,
-    GuildNewsChannel,
-    GuildNewsThread,
-    GuildPrivateThread,
-    GuildPublicThread,
-    GuildStageChannel,
-    GuildTextChannel,
-    GuildVoiceChannel,
     InteractionChannel,
     OptionType,
     PartialChannel,
     Role,
-    UndefinedNoneOr,
     UndefinedOr,
     User,
 )
 
 from crescent.locale import LocaleBuilder, str_or_build_locale
 from crescent.mentionable import Mentionable
-
-if TYPE_CHECKING:
-    from crescent.typedefs import AutocompleteCallbackT, OptionTypesT
-
+from crescent.typedefs import AutocompleteCallbackT
 
 __all__ = (
-    "OPTIONS_TYPE_MAP",
-    "VALID_CHANNEL_TYPES",
-    "CHANNEL_TYPE_MAP",
-    "get_channel_types",
-    "option",
+    "Marker",
+    "StrMarker",
+    "BoolMarker",
+    "IntMarker",
+    "FloatMarker",
+    "ChannelMarker",
+    "RoleMarker",
+    "UserMarker",
+    "MentionableMarker",
+    "AttachmentMarker",
     "ClassCommandOption",
+    "string",
+    "boolean",
+    "number",
+    "floating",
+    "channel",
+    "role",
+    "user",
+    "mentionable",
+    "attachment",
 )
 
-OPTIONS_TYPE_MAP: dict[type[OptionTypesT], OptionType] = {
-    str: OptionType.STRING,
-    bool: OptionType.BOOLEAN,
-    int: OptionType.INTEGER,
-    float: OptionType.FLOAT,
-    PartialChannel: OptionType.CHANNEL,
-    Role: OptionType.ROLE,
-    User: OptionType.USER,
-    Mentionable: OptionType.MENTIONABLE,
-    Attachment: OptionType.ATTACHMENT,
-}
-VALID_CHANNEL_TYPES = Union[
-    GuildTextChannel,
-    DMChannel,
-    GroupDMChannel,
-    GuildVoiceChannel,
-    GuildCategory,
-    GuildNewsChannel,
-    GuildNewsThread,
-    GuildPublicThread,
-    GuildPrivateThread,
-    GuildStageChannel,
-    GuildForumChannel,
-]
-CHANNEL_TYPE_MAP: dict[type[VALID_CHANNEL_TYPES], ChannelType] = {
-    GuildTextChannel: ChannelType.GUILD_TEXT,
-    DMChannel: ChannelType.DM,
-    GuildVoiceChannel: ChannelType.GUILD_VOICE,
-    GroupDMChannel: ChannelType.GROUP_DM,
-    GuildCategory: ChannelType.GUILD_CATEGORY,
-    GuildNewsChannel: ChannelType.GUILD_NEWS,
-    GuildNewsThread: ChannelType.GUILD_NEWS_THREAD,
-    GuildPublicThread: ChannelType.GUILD_PUBLIC_THREAD,
-    GuildPrivateThread: ChannelType.GUILD_PRIVATE_THREAD,
-    GuildStageChannel: ChannelType.GUILD_STAGE,
-    GuildForumChannel: ChannelType.GUILD_FORUM,
-}
+
+# fmt: off
+class Marker: ...
+class StrMarker(Marker): ...
+class BoolMarker(Marker): ...
+class IntMarker(Marker): ...
+class FloatMarker(Marker): ...
+class ChannelMarker(Marker): ...
+class RoleMarker(Marker): ...
+class UserMarker(Marker): ...
+class MentionableMarker(Marker): ...
+class AttachmentMarker(Marker): ...
+# fmt: on
 
 
-def build_choices(
-    choices: Sequence[tuple[str | LocaleBuilder, str | int | float]],
+MarkT = TypeVar("MarkT", bound=Marker)
+InT = TypeVar("InT")
+ConverterT = TypeVar("ConverterT")
+DefaultT = TypeVar("DefaultT")
+ChannelTypeT = TypeVar("ChannelTypeT", bound=PartialChannel)
+T = TypeVar("T")
+
+
+def _build_choices(
+    choices: Sequence[tuple[str | LocaleBuilder, str | int | float] | CommandChoice],
 ) -> list[CommandChoice]:
     result: list[CommandChoice] = []
-    for name, value in choices:
+    for choice in choices:
+        if isinstance(choice, CommandChoice):
+            result.append(choice)
+            continue
+
+        name, value = choice
         name, name_localizations = str_or_build_locale(name)
         result.append(CommandChoice(name=name, name_localizations=name_localizations, value=value))
 
     return result
 
 
-def get_channel_types(*channels: type[PartialChannel]) -> set[ChannelType]:
-    if len(channels) == 1 and channels[0] is PartialChannel:
-        return set()
+@dataclass(slots=True)
+class ClassCommandOption(Generic[MarkT, InT, ConverterT, DefaultT]):
+    """A declarative option definition used by class-based slash commands.
 
-    types: set[ChannelType] = set()
-    for k, v in CHANNEL_TYPE_MAP.items():
-        if issubclass(k, channels):  # pyright: ignore
-            types.add(v)
+    Instances of this class are usually created through the builder objects
+    exported by this module, such as [`string`][crescent.commands.options.string]
+    or [`channel`][crescent.commands.options.channel].
+    """
 
-    return types
+    _type: OptionType
+    _description: str | LocaleBuilder
+    _name: UndefinedOr[str | LocaleBuilder] = UNDEFINED
+    _default: UndefinedOr[DefaultT] = UNDEFINED
+    _choices: Sequence[CommandChoice] | None = None
+    _channel_types: Sequence[ChannelType] | None = None
+    _min_value: int | float | None = None
+    _max_value: int | float | None = None
+    _min_length: int | None = None
+    _max_length: int | None = None
+    _autocomplete: AutocompleteCallbackT[Any] | None = None
+    _converter: Callable[[InT], ConverterT | Awaitable[ConverterT]] | None = None
 
+    def name(self, name: str | LocaleBuilder) -> Self:
+        """Set the Discord-facing name for this option."""
+        return replace(self, _name=name)
 
-T = TypeVar("T")
-In = TypeVar("In")
-Out = TypeVar("Out")
-Self = TypeVar("Self")
-
-
-@dataclass
-class ClassCommandOption(Generic[In, Out]):
-    name: str | LocaleBuilder | None
-    type: OptionType
-    description: str | LocaleBuilder
-    default: UndefinedNoneOr[Any]
-    choices: Sequence[CommandChoice] | None
-    channel_types: Sequence[ChannelType] | None
-    min_value: int | float | None
-    max_value: int | float | None
-    min_length: int | None
-    max_length: int | None
-    autocomplete: AutocompleteCallbackT[Any] | None
-    converter: Callable[[In], Out | Awaitable[Out]] | None
-
-    def convert(self, converter: Callable[[In], T | Awaitable[T]]) -> ClassCommandOption[In, T]:
-        return replace(cast("ClassCommandOption[In, T]", self), converter=converter)
-
-    def _gen_option(self, name: str) -> CommandOption:
-        name, name_localizations = str_or_build_locale(self.name or name)
-        description, description_localizations = str_or_build_locale(self.description)
-
-        return CommandOption(
-            type=self.type,
-            name=name,
-            name_localizations=name_localizations,
-            description=description,
-            description_localizations=description_localizations,
-            is_required=self.default is UNDEFINED,
-            choices=self.choices,
-            channel_types=self.channel_types,
-            min_value=self.min_value,
-            max_value=self.max_value,
-            min_length=self.min_length,
-            max_length=self.max_length,
-            autocomplete=bool(self.autocomplete),
+    def default(self, default: T) -> "ClassCommandOption[MarkT, InT, ConverterT, T]":
+        """Set a default value, making this option optional."""
+        return replace(
+            cast("ClassCommandOption[MarkT, InT, ConverterT, T]", self),
+            _default=default,
         )
 
-    @overload
-    def __get__(self: Self, inst: None, cls: Any) -> Self: ...
+    def convert(
+        self, converter: Callable[[InT], T | Awaitable[T]]
+    ) -> "ClassCommandOption[MarkT, InT, T, DefaultT]":
+        """Convert the raw option value before assigning it to the command instance."""
+        return replace(
+            cast("ClassCommandOption[MarkT, InT, T, DefaultT]", self),
+            _converter=converter,
+        )
+
+    def channel_types(
+        self: "ClassCommandOption[ChannelMarker, InT, ConverterT, DefaultT]",
+        types: Sequence[ChannelType],
+    ) -> "ClassCommandOption[ChannelMarker, InT, ConverterT, DefaultT]":
+        """Restrict which Discord channel types may be selected for this option."""
+        return replace(self, _channel_types=types)
 
     @overload
-    def __get__(self, inst: object, cls: Any) -> Out: ...
+    def autocomplete(
+        self: "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]",
+        autocomplete: AutocompleteCallbackT[int],
+    ) -> "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]": ...
+    @overload
+    def autocomplete(
+        self: "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]",
+        autocomplete: AutocompleteCallbackT[float],
+    ) -> "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]": ...
+    @overload
+    def autocomplete(
+        self: "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]",
+        autocomplete: AutocompleteCallbackT[str],
+    ) -> "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]": ...
+
+    def autocomplete(self, autocomplete: AutocompleteCallbackT[Any]) -> Any:
+        """Attach an autocomplete callback to this option."""
+        return replace(self, _autocomplete=autocomplete)
+
+    @overload
+    def choices(
+        self: "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]",
+        choices: Sequence[tuple[str | LocaleBuilder, int] | CommandChoice],
+    ) -> "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]": ...
+    @overload
+    def choices(
+        self: "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]",
+        choices: Sequence[tuple[str | LocaleBuilder, float] | CommandChoice],
+    ) -> "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]": ...
+    @overload
+    def choices(
+        self: "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]",
+        choices: Sequence[tuple[str | LocaleBuilder, str] | CommandChoice],
+    ) -> "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]": ...
+
+    def choices(
+        self, choices: Sequence[tuple[str | LocaleBuilder, int | str | float] | CommandChoice]
+    ) -> Any:
+        """Set the fixed choices users may select for this option."""
+        return replace(self, _choices=_build_choices(choices))
+
+    @overload
+    def min_value(
+        self: "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]",
+        value: int,
+    ) -> "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]": ...
+
+    @overload
+    def min_value(
+        self: "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]",
+        value: float,
+    ) -> "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]": ...
+
+    def min_value(self, value: int | float) -> Any:
+        """Set the inclusive minimum numeric value for this option."""
+        return replace(self, _min_value=value)
+
+    @overload
+    def max_value(
+        self: "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]",
+        value: int,
+    ) -> "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]": ...
+
+    @overload
+    def max_value(
+        self: "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]",
+        value: float,
+    ) -> "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]": ...
+
+    def max_value(self, value: int | float) -> Any:
+        """Set the inclusive maximum numeric value for this option."""
+        return replace(self, _max_value=value)
+
+    def min_length(
+        self: "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]",
+        value: int,
+    ) -> "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]":
+        """Set the inclusive minimum string length for this option."""
+        return replace(self, _min_length=value)
+
+    def max_length(
+        self: "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]",
+        value: int,
+    ) -> "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]":
+        """Set the inclusive maximum string length for this option."""
+        return replace(self, _max_length=value)
+
+    @overload
+    def __get__(self, inst: None, cls: Any) -> Self: ...
+
+    @overload
+    def __get__(
+        self: "ClassCommandOption[MarkT, InT, Never, Never]", inst: object, cls: Any
+    ) -> InT: ...
+    @overload
+    def __get__(
+        self: "ClassCommandOption[MarkT, InT, ConverterT, Never]", inst: object, cls: Any
+    ) -> ConverterT: ...
+    @overload
+    def __get__(
+        self: "ClassCommandOption[MarkT, InT, Never, DefaultT]", inst: object, cls: Any
+    ) -> InT | DefaultT: ...
+    @overload
+    def __get__(
+        self: "ClassCommandOption[MarkT, InT, ConverterT, DefaultT]", inst: object, cls: Any
+    ) -> ConverterT | DefaultT: ...
 
     def __get__(self, inst: Any | None, cls: Any) -> Any:
         if inst is None:
@@ -175,321 +250,48 @@ class ClassCommandOption(Generic[In, Out]):
         # we should never reach this point
         raise NotImplementedError
 
+    def _gen_option(self, name: str) -> CommandOption:
+        name, name_localizations = str_or_build_locale(self._name or name)
+        description, description_localizations = str_or_build_locale(self._description)
 
-DEFAULT = TypeVar("DEFAULT")
-
-# mypy doesn't understand abstract classes, so this is necessary and hence # pyright: ignore
-# (github issues 4717, 5374)
-USER = TypeVar("USER", bound="type[User]")
-ROLE = TypeVar("ROLE", bound="type[Role]")
-ATTACHMENT = TypeVar("ATTACHMENT", bound="type[Attachment]")
-
-
-@overload
-def option(
-    option_type: type[PartialChannel] | Sequence[type[PartialChannel]],
-    description: str | LocaleBuilder = ...,
-    *,
-    name: str | LocaleBuilder | None = ...,
-) -> ClassCommandOption[InteractionChannel, InteractionChannel]: ...
-
-
-@overload
-def option(
-    option_type: type[PartialChannel] | Sequence[type[PartialChannel]],
-    description: str | LocaleBuilder = ...,
-    *,
-    default: DEFAULT,
-    name: str | LocaleBuilder | None = ...,
-) -> ClassCommandOption[InteractionChannel | DEFAULT, InteractionChannel | DEFAULT]: ...
+        return CommandOption(
+            type=self._type,
+            name=name,
+            name_localizations=name_localizations,
+            description=description,
+            description_localizations=description_localizations,
+            is_required=self._default is UNDEFINED,
+            choices=self._choices,
+            channel_types=self._channel_types,
+            min_value=self._min_value,
+            max_value=self._max_value,
+            min_length=self._min_length,
+            max_length=self._max_length,
+            autocomplete=self._autocomplete is not None,
+        )
 
 
-# fmt: off
-@overload
-def option(
-    option_type: USER,  # pyright: ignore
-    description: str | LocaleBuilder = ...,
-    *,
-    name: str | LocaleBuilder | None = ...,
-) -> ClassCommandOption[User, User]:
-    ...
-# fmt: on
+@dataclass(slots=True, frozen=True)
+class _OptionBuilder(Generic[MarkT, InT]):
+    """Internal callable builder for a specific Discord option type."""
+
+    _type: OptionType
+
+    def __call__(
+        self, description: str | LocaleBuilder
+    ) -> ClassCommandOption[MarkT, InT, Never, Never]:
+        """Create an option declaration with the provided description."""
+        return ClassCommandOption(_description=description, _type=self._type)
 
 
-@overload
-def option(
-    option_type: USER,  # pyright: ignore
-    description: str | LocaleBuilder = ...,
-    *,
-    default: DEFAULT,
-    name: str | LocaleBuilder | None = ...,
-) -> ClassCommandOption[User | DEFAULT, User | DEFAULT]: ...
-
-
-# fmt: off
-@overload
-def option(
-    option_type: ROLE,  # pyright: ignore
-    description: str | LocaleBuilder = ...,
-    *,
-    name: str | LocaleBuilder | None = ...,
-) -> ClassCommandOption[Role, Role]:
-    ...
-# fmt: on
-
-
-@overload
-def option(
-    option_type: ROLE,  # pyright: ignore
-    description: str | LocaleBuilder = ...,
-    *,
-    default: DEFAULT,
-    name: str | LocaleBuilder | None = ...,
-) -> ClassCommandOption[Role | DEFAULT, Role | DEFAULT]: ...
-
-
-# fmt: off
-@overload
-def option(
-    option_type: ATTACHMENT,  # pyright: ignore
-    description: str | LocaleBuilder = ...,
-    *,
-    name: str | LocaleBuilder | None = ...,
-) -> ClassCommandOption[Attachment, Attachment]:
-    ...
-# fmt: on
-
-
-@overload
-def option(
-    option_type: ATTACHMENT,  # pyright: ignore
-    description: str | LocaleBuilder = ...,
-    *,
-    default: DEFAULT,
-    name: str | LocaleBuilder | None = ...,
-) -> ClassCommandOption[Attachment | DEFAULT, Attachment | DEFAULT]: ...
-
-
-@overload
-def option(
-    option_type: type[Mentionable],
-    description: str | LocaleBuilder = ...,
-    *,
-    name: str | LocaleBuilder | None = ...,
-) -> ClassCommandOption[Mentionable, Mentionable]: ...
-
-
-@overload
-def option(
-    option_type: type[Mentionable],
-    description: str | LocaleBuilder = ...,
-    *,
-    default: DEFAULT,
-    name: str | LocaleBuilder | None = ...,
-) -> ClassCommandOption[Mentionable | DEFAULT, Mentionable | DEFAULT]: ...
-
-
-# We have type ignores here because bool and float both inherit from int.
-# This makes the typechecker wrongly believe that the overloads overlap.
-
-
-@overload
-def option(  # type: ignore
-    option_type: type[bool],
-    description: str | LocaleBuilder = ...,
-    *,
-    name: str | LocaleBuilder | None = ...,
-) -> ClassCommandOption[bool, bool]: ...
-
-
-@overload
-def option(  # type: ignore
-    option_type: type[bool],
-    description: str | LocaleBuilder = ...,
-    *,
-    default: DEFAULT,
-    name: str | LocaleBuilder | None = ...,
-) -> ClassCommandOption[bool | DEFAULT, bool | DEFAULT]: ...
-
-
-@overload
-def option(  # type: ignore
-    option_type: type[int],
-    description: str | LocaleBuilder = ...,
-    *,
-    choices: Sequence[tuple[str | LocaleBuilder, int]] | None = ...,
-    autocomplete: AutocompleteCallbackT[int] | None = ...,
-    min_value: int | None = ...,
-    max_value: int | None = ...,
-    name: str | LocaleBuilder | None = ...,
-) -> ClassCommandOption[int, int]: ...
-
-
-@overload
-def option(  # type: ignore
-    option_type: type[int],
-    description: str | LocaleBuilder = ...,
-    *,
-    default: DEFAULT,
-    choices: Sequence[tuple[str | LocaleBuilder, int]] | None = ...,
-    autocomplete: AutocompleteCallbackT[int] | None = ...,
-    min_value: int | None = ...,
-    max_value: int | None = ...,
-    name: str | LocaleBuilder | None = ...,
-) -> ClassCommandOption[int | DEFAULT, int | DEFAULT]: ...
-
-
-@overload
-def option(
-    option_type: type[float],
-    description: str | LocaleBuilder = ...,
-    *,
-    choices: Sequence[tuple[str | LocaleBuilder, float]] | None = ...,
-    autocomplete: AutocompleteCallbackT[float] | None = ...,
-    min_value: float | None = ...,
-    max_value: float | None = ...,
-    name: str | LocaleBuilder | None = ...,
-) -> ClassCommandOption[float, float]: ...
-
-
-@overload
-def option(
-    option_type: type[float],
-    description: str | LocaleBuilder = ...,
-    *,
-    default: DEFAULT,
-    choices: Sequence[tuple[str | LocaleBuilder, float]] | None = ...,
-    autocomplete: AutocompleteCallbackT[float] | None = ...,
-    min_value: float | None = ...,
-    max_value: float | None = ...,
-    name: str | LocaleBuilder | None = ...,
-) -> ClassCommandOption[float | DEFAULT, float | DEFAULT]: ...
-
-
-@overload
-def option(
-    option_type: type[str],
-    description: str | LocaleBuilder = ...,
-    *,
-    min_length: int | None = ...,
-    max_length: int | None = ...,
-    choices: Sequence[tuple[str | LocaleBuilder, str]] | None = ...,
-    autocomplete: AutocompleteCallbackT[str] | None = ...,
-    name: str | LocaleBuilder | None = ...,
-) -> ClassCommandOption[str, str]: ...
-
-
-@overload
-def option(
-    option_type: type[str],
-    description: str | LocaleBuilder = ...,
-    *,
-    default: DEFAULT,
-    min_length: int | None = ...,
-    max_length: int | None = ...,
-    choices: Sequence[tuple[str | LocaleBuilder, str]] | None = ...,
-    autocomplete: AutocompleteCallbackT[str] | None = ...,
-    name: str | LocaleBuilder | None = ...,
-) -> ClassCommandOption[str | DEFAULT, int | DEFAULT]: ...
-
-
-def option(
-    option_type: type[OptionTypesT] | Sequence[type[PartialChannel]],
-    description: str | LocaleBuilder = "No Description",
-    *,
-    name: str | LocaleBuilder | None = None,
-    default: UndefinedOr[Any] = UNDEFINED,
-    choices: Sequence[tuple[str | LocaleBuilder, str | int | float]] | None = None,
-    min_value: int | float | None = None,
-    max_value: int | float | None = None,
-    min_length: int | None = None,
-    max_length: int | None = None,
-    autocomplete: AutocompleteCallbackT[Any] | None = None,
-) -> ClassCommandOption[Any, Any]:
-    """
-    An option when declaring a command using class syntax.
-
-    ### Example
-    ```python
-    @client.include
-    @crescent.command(name="say")
-    class Say:
-        word = crescent.option(str)
-
-        async def callback(self, ctx: crescent.Context):
-            await ctx.respond(self.word)
-    ```
-
-    Args:
-        description:
-            The description for this option. Defaults to "No Description".
-        name:
-            The name to use for this option. By default, the name of the
-            property on the option the option is set to will be used for the
-            name. In the above example the name would be `word`.
-        default:
-            The default value for this option. Specifying this will make this
-            option optional.
-        choices:
-            A set of choices a user can pick from for this option. Only available
-            for `int`, `str`, and `float` option types.
-        min_value:
-            The minimum value for a number the user inputs. Only available for
-            `int` and `float` option types.
-        man_value:
-            The maximum value for a number the user inputs. Only available for
-            `int` and `float` option types.
-        min_length:
-            The minimum length for a `str` that the user inputs.
-        max_length:
-            The maximum length for a `str` that the user inputs.
-        autocomplete:
-            An autocomplete callback for this option.
-
-            ### Example
-            ```python
-            async def autocomplete_response(
-                ctx: crescent.AutocompleteContext, option: hikari.AutocompleteInteractionOption
-            ) -> list[tuple[str, str]]:
-                # Return a list of tuples of (option name, option value)
-                return [("Some Option", "1234")]
-
-            @client.include
-            @crescent.command
-            class autocomplete:
-                result = crescent.option(str, "Respond to the message", autocomplete=autocomplete_response)
-
-                async def callback(self, ctx: crescent.Context) -> None:
-                    await ctx.respond(self.result, ephemeral=True)
-            ```
-    """  # noqa: E501
-    _option_type: type[OptionTypesT]
-    if (
-        isinstance(option_type, type)
-        and issubclass(option_type, PartialChannel)
-        and option_type is not PartialChannel
-    ):
-        option_type = cast("type[VALID_CHANNEL_TYPES]", option_type)
-        channel_types = get_channel_types(option_type)
-        _option_type = PartialChannel
-    elif isinstance(option_type, Sequence):
-        channel_types = get_channel_types(*option_type)
-        _option_type = PartialChannel
-    else:
-        _option_type = option_type
-        channel_types = None
-
-    return ClassCommandOption(
-        type=OPTIONS_TYPE_MAP[_option_type],
-        description=description,
-        default=default,
-        choices=build_choices(choices) if choices else None,
-        channel_types=list(channel_types) if channel_types else None,
-        min_value=min_value,
-        max_value=max_value,
-        min_length=min_length,
-        max_length=max_length,
-        name=name,
-        autocomplete=autocomplete,
-        converter=None,
-    )
+string: _OptionBuilder[StrMarker, str] = _OptionBuilder(OptionType.STRING)
+boolean: _OptionBuilder[BoolMarker, bool] = _OptionBuilder(OptionType.BOOLEAN)
+number: _OptionBuilder[IntMarker, int] = _OptionBuilder(OptionType.INTEGER)
+floating: _OptionBuilder[FloatMarker, float] = _OptionBuilder(OptionType.FLOAT)
+channel: _OptionBuilder[ChannelMarker, InteractionChannel] = _OptionBuilder(OptionType.CHANNEL)
+role: _OptionBuilder[RoleMarker, Role] = _OptionBuilder(OptionType.ROLE)
+user: _OptionBuilder[UserMarker, User] = _OptionBuilder(OptionType.USER)
+mentionable: _OptionBuilder[MentionableMarker, Mentionable] = _OptionBuilder(
+    OptionType.MENTIONABLE
+)
+attachment: _OptionBuilder[AttachmentMarker, Attachment] = _OptionBuilder(OptionType.ATTACHMENT)

--- a/crescent/context/__init__.py
+++ b/crescent/context/__init__.py
@@ -1,7 +1,7 @@
-from typing import Sequence
+from __future__ import annotations
 
-from crescent.context.autocomplete_context import *
-from crescent.context.context import *
-from crescent.context.interaction_context import *
+from crescent.context.autocomplete_context import AutocompleteContext
+from crescent.context.context import Context
+from crescent.context.interaction_context import InteractionContext
 
-__all__: Sequence[str] = ("InteractionContext", "Context", "AutocompleteContext")
+__all__ = ("AutocompleteContext", "Context", "InteractionContext")

--- a/crescent/context/autocomplete_context.py
+++ b/crescent/context/autocomplete_context.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Sequence
+from typing import TYPE_CHECKING, Any
 
 from hikari import (
     AutocompleteInteraction,
@@ -19,7 +19,10 @@ from crescent.context.interaction_context import InteractionContext
 from crescent.mentionable import Mentionable
 from crescent.utils import gather_iter
 
-__all__: Sequence[str] = ("AutocompleteContext",)
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+__all__ = ("AutocompleteContext",)
 
 
 async def _fetch_user(ctx: AutocompleteContext, value: Snowflake) -> User | Member:
@@ -33,16 +36,14 @@ async def _fetch_user(ctx: AutocompleteContext, value: Snowflake) -> User | Memb
 
     if ctx.guild_id:
         return await ctx.app.rest.fetch_member(ctx.guild_id, value)
-    else:
-        return await ctx.app.rest.fetch_user(value)
+    return await ctx.app.rest.fetch_user(value)
 
 
 async def _fetch_role(ctx: AutocompleteContext, value: Snowflake) -> Role:
     assert ctx.guild_id
 
-    if isinstance(ctx.app, CacheAware):
-        if role := ctx.app.cache.get_role(value):
-            return role
+    if isinstance(ctx.app, CacheAware) and (role := ctx.app.cache.get_role(value)):
+        return role
 
     roles = await ctx.app.rest.fetch_roles(ctx.guild_id)
     return next(filter(lambda r: r.id == value, roles))
@@ -66,9 +67,8 @@ async def _fetch_mentionable(ctx: AutocompleteContext, value: Snowflake) -> Ment
 
 
 async def _fetch_channel(ctx: AutocompleteContext, value: Snowflake) -> PartialChannel:
-    if isinstance(ctx.app, CacheAware):
-        if channel := ctx.app.cache.get_guild_channel(value):
-            return channel
+    if isinstance(ctx.app, CacheAware) and (channel := ctx.app.cache.get_guild_channel(value)):
+        return channel
 
     return await ctx.app.rest.fetch_channel(value)
 

--- a/crescent/context/context.py
+++ b/crescent/context/context.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Union, overload
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 from hikari import (
     UNDEFINED,
@@ -22,7 +22,7 @@ from crescent.context.interaction_context import InteractionContext
 from crescent.exceptions import InteractionAlreadyAcknowledgedError
 
 if TYPE_CHECKING:
-    from typing import Any, Literal, Sequence
+    from collections.abc import Sequence
 
     from hikari import (
         Attachment,
@@ -38,11 +38,9 @@ if TYPE_CHECKING:
         UndefinedType,
     )
 
-__all__: Sequence[str] = ("Context",)
+__all__ = ("Context",)
 
-ResponseBuilderT = Union[
-    InteractionMessageBuilder, InteractionDeferredBuilder, InteractionModalBuilder
-]
+ResponseBuilderT = InteractionMessageBuilder | InteractionDeferredBuilder | InteractionModalBuilder
 
 
 class Context(InteractionContext):
@@ -58,7 +56,7 @@ class Context(InteractionContext):
         """
         if isinstance(self.app, CacheAware):
             return self.app.cache.get_guild_channel(self.channel_id) or self.app.cache.get_thread(
-                self.channel_id
+                self.channel_id,
             )
         return None
 
@@ -67,7 +65,7 @@ class Context(InteractionContext):
         """Get this context's guild from the cache."""
         return self.interaction.get_guild()
 
-    async def defer(self, ephemeral: bool = False) -> None:
+    async def defer(self, *, ephemeral: bool = False) -> None:
         """
         Defer this interaction response, allowing you to respond within the next 15
         minutes.
@@ -204,18 +202,18 @@ class Context(InteractionContext):
             else:
                 flags |= MessageFlag.EPHEMERAL
 
-        kwargs: dict[str, Any] = dict(
-            content=content,
-            attachment=attachment,
-            attachments=attachments,
-            component=component,
-            components=components,
-            embed=embed,
-            embeds=embeds,
-            mentions_everyone=mentions_everyone,
-            user_mentions=user_mentions,
-            role_mentions=role_mentions,
-        )
+        kwargs: dict[str, Any] = {
+            "content": content,
+            "attachment": attachment,
+            "attachments": attachments,
+            "component": component,
+            "components": components,
+            "embed": embed,
+            "embeds": embeds,
+            "mentions_everyone": mentions_everyone,
+            "user_mentions": user_mentions,
+            "role_mentions": role_mentions,
+        }
 
         if not (self._has_deferred_response or self._has_created_response):
             if future := self._unset_future:
@@ -270,7 +268,10 @@ class Context(InteractionContext):
         return await self.followup(**kwargs)
 
     async def respond_with_modal(
-        self, title: str, custom_id: str, components: Sequence[ComponentBuilder]
+        self,
+        title: str,
+        custom_id: str,
+        components: Sequence[ComponentBuilder],
     ) -> None:
         """Respond to an interaction with a modal.
 
@@ -288,7 +289,7 @@ class Context(InteractionContext):
         """
         if self._has_created_response or self._has_deferred_response:
             raise InteractionAlreadyAcknowledgedError(
-                "You cannot use this method after already responding to an interaction."
+                "You cannot use this method after already responding to an interaction.",
             )
 
         if future := self._unset_future:
@@ -298,12 +299,17 @@ class Context(InteractionContext):
             future.set_result(builder)
         else:
             await self.interaction.create_modal_response(
-                title=title, custom_id=custom_id, components=components
+                title=title,
+                custom_id=custom_id,
+                components=components,
             )
         self._has_created_response = True
 
     async def respond_with_builder(
-        self, builder: ResponseBuilderT, ensure_message: bool = False
+        self,
+        builder: ResponseBuilderT,
+        *,
+        ensure_message: bool = False,
     ) -> Message | None:
         """Respond to an interaction with a builder.
 
@@ -323,7 +329,7 @@ class Context(InteractionContext):
         """
         if self._has_created_response or self._has_deferred_response:
             raise InteractionAlreadyAcknowledgedError(
-                "This method cannot be used after already responding to an interaction."
+                "This method cannot be used after already responding to an interaction.",
             )
 
         if future := self._unset_future:
@@ -344,11 +350,14 @@ class Context(InteractionContext):
                 )
             elif isinstance(builder, InteractionDeferredBuilder):
                 await self.interaction.create_initial_response(
-                    response_type=ResponseType.DEFERRED_MESSAGE_CREATE, flags=builder.flags
+                    response_type=ResponseType.DEFERRED_MESSAGE_CREATE,
+                    flags=builder.flags,
                 )
             else:
                 await self.interaction.create_modal_response(
-                    title=builder.title, custom_id=builder.custom_id, components=builder.components
+                    title=builder.title,
+                    custom_id=builder.custom_id,
+                    components=builder.components,
                 )
         self._has_created_response = True
 
@@ -472,5 +481,6 @@ class Context(InteractionContext):
         ```
         """
         await self.app.rest.delete_interaction_response(
-            application=self.application_id, token=self.token
+            application=self.application_id,
+            token=self.token,
         )

--- a/crescent/context/interaction_context.py
+++ b/crescent/context/interaction_context.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
-
-import hikari
-from hikari import Locale, Member, PartialInteraction, Snowflake, User
+from typing import TYPE_CHECKING, Any, TypeVar
 
 if TYPE_CHECKING:
+    import builtins
     from asyncio import Future
-    from typing import Any, Sequence, Type, TypeVar
+    from collections.abc import Sequence
 
+    import hikari
+    from hikari import Locale, Member, PartialInteraction, Snowflake, User
     from hikari.api import InteractionResponseBuilder
 
     from crescent.client import Client, GatewayTraits, RESTTraits
@@ -17,38 +17,12 @@ if TYPE_CHECKING:
     ContextT = TypeVar("ContextT", bound="InteractionContext")
 
 
-__all__: Sequence[str] = ("InteractionContext",)
+__all__ = ("InteractionContext",)
 
 
-@dataclass
+@dataclass(slots=True)
 class InteractionContext:
     """Represents the context for interactions"""
-
-    __slots__ = (
-        "interaction",
-        "app",
-        "client",
-        "application_id",
-        "type",
-        "token",
-        "id",
-        "version",
-        "channel_id",
-        "guild_id",
-        "registered_guild_id",
-        "user",
-        "member",
-        "entitlements",
-        "locale",
-        "command",
-        "command_type",
-        "group",
-        "sub_group",
-        "options",
-        "_has_created_response",
-        "_has_deferred_response",
-        "_rest_interaction_future",
-    )
 
     interaction: PartialInteraction
     """The interaction object."""
@@ -117,11 +91,10 @@ class InteractionContext:
             return self._rest_interaction_future
         return None
 
-    def into(self, context_t: Type[ContextT]) -> ContextT:
+    def into(self, context_t: builtins.type[ContextT]) -> ContextT:
         """Convert to a context of a different type."""
         if type(self) is context_t:
-            # pyright can't tell this is of type `context_t`
-            return self  # pyright: ignore
+            return self
 
         return context_t(
             interaction=self.interaction,

--- a/crescent/errors.py
+++ b/crescent/errors.py
@@ -1,22 +1,25 @@
 from __future__ import annotations
 
-from typing import Any, Awaitable, Callable, Sequence, TypeVar
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from crescent.internal.includable import Includable
-from crescent.typedefs import (
-    AutocompleteErrorHandlerCallbackT,
-    CommandErrorHandlerCallbackT,
-    EventErrorHandlerCallbackT,
-)
 
-__all__: Sequence[str] = ("catch_command", "catch_event", "catch_autocomplete")
+if TYPE_CHECKING:
+    from crescent.typedefs import (
+        AutocompleteErrorHandlerCallbackT,
+        CommandErrorHandlerCallbackT,
+        EventErrorHandlerCallbackT,
+    )
+
+__all__ = ("catch_autocomplete", "catch_command", "catch_event")
 
 
 T = TypeVar("T", bound=Callable[..., Awaitable[Any]])
 
 
 def _make_catch_function(
-    error_handler_var: str, supports_custom_ctx: bool = False
+    error_handler_var: str,
 ) -> Callable[[type[Exception]], Callable[[T], Includable[T]]]:
     def func(*exceptions: type[Exception]) -> Callable[[T], Includable[T]]:
         def app_set_hook(includable: Includable[Any]) -> None:
@@ -28,20 +31,20 @@ def _make_catch_function(
                 getattr(includable.client, error_handler_var).remove(exc)
 
         def decorator(callback: Any) -> Includable[Any]:
-            includable = Includable(
-                callback, client_set_hooks=[app_set_hook], plugin_unload_hooks=[plugin_unload_hook]
+            return Includable(
+                callback,
+                client_set_hooks=[app_set_hook],
+                plugin_unload_hooks=[plugin_unload_hook],
             )
-
-            return includable
 
         return decorator
 
     return func
 
 
-_catch_command = _make_catch_function("_command_error_handler", supports_custom_ctx=True)
+_catch_command = _make_catch_function("_command_error_handler")
 _catch_event = _make_catch_function("_event_error_handler")
-_catch_autocomplete = _make_catch_function("_autocomplete_error_handler", supports_custom_ctx=True)
+_catch_autocomplete = _make_catch_function("_autocomplete_error_handler")
 
 
 # NOTE: These functions are defined to help properly type the user facings functions and
@@ -97,7 +100,8 @@ def catch_event(
 def catch_autocomplete(
     *exceptions: type[Exception],
 ) -> Callable[
-    [AutocompleteErrorHandlerCallbackT[Any]], Includable[AutocompleteErrorHandlerCallbackT[Any]]
+    [AutocompleteErrorHandlerCallbackT[Any]],
+    Includable[AutocompleteErrorHandlerCallbackT[Any]],
 ]:
     """
     Catch an exception or subclasses of an exception passed into this function when the

--- a/crescent/events.py
+++ b/crescent/events.py
@@ -3,51 +3,63 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from functools import partial
 from inspect import iscoroutinefunction
-from typing import TYPE_CHECKING, Generic, TypeVar, get_type_hints, overload
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, get_type_hints, overload
 
 from hikari import EventManagerAware
 
 from crescent.internal.includable import Includable
-from crescent.typedefs import EventHookCallbackT
 from crescent.utils import add_hooks
 from crescent.utils.options import unwrap
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Coroutine, Sequence
+    from collections.abc import Callable, Coroutine, Sequence
 
     from hikari import Event
     from hikari.api.event_manager import CallbackT
 
-EventT = TypeVar("EventT", bound="Event", contravariant=True)
+    from crescent.typedefs import EventHookCallbackT
 
-__all__: Sequence[str] = ("event",)
+EventT_contra = TypeVar("EventT_contra", bound="Event", contravariant=True)
+
+__all__ = ("event",)
 
 
 @dataclass
-class EventMeta(Generic[EventT]):
-    callback: CallbackT[EventT]
-    hooks: list[EventHookCallbackT[EventT]] = field(default_factory=list)  # pyright: ignore[reportUnknownVariableType]
-    after_hooks: list[EventHookCallbackT[EventT]] = field(default_factory=list)  # pyright: ignore[reportUnknownVariableType]
+class EventMeta(Generic[EventT_contra]):
+    callback: CallbackT[EventT_contra]
+    hooks: list[EventHookCallbackT[EventT_contra]] = field(default_factory=list)  # pyright: ignore[reportUnknownVariableType]
+    after_hooks: list[EventHookCallbackT[EventT_contra]] = field(default_factory=list)  # pyright: ignore[reportUnknownVariableType]
 
     def add_hooks(
-        self, hooks: Sequence[EventHookCallbackT[Any]], prepend: bool = False, *, after: bool
+        self,
+        hooks: Sequence[EventHookCallbackT[Any]],
+        *,
+        prepend: bool = False,
+        after: bool,
     ) -> None:
         add_hooks(self.hooks, self.after_hooks, hooks, prepend=prepend, after=after)
 
 
 @overload
-def event(callback: CallbackT[EventT], /) -> Includable[EventMeta[EventT]]: ...
+def event(callback: CallbackT[EventT_contra], /) -> Includable[EventMeta[EventT_contra]]: ...
 
 
 @overload
 def event(
-    *, event_type: type[EventT] | None
-) -> Callable[[CallbackT[EventT]], Includable[EventMeta[EventT]]]: ...
+    *,
+    event_type: type[EventT_contra] | None,
+) -> Callable[[CallbackT[EventT_contra]], Includable[EventMeta[EventT_contra]]]: ...
 
 
 def event(
-    callback: CallbackT[EventT] | None = None, /, *, event_type: type[EventT] | None = None
-) -> Callable[[CallbackT[EventT]], Includable[EventMeta[EventT]]] | Includable[EventMeta[EventT]]:
+    callback: CallbackT[EventT_contra] | None = None,
+    /,
+    *,
+    event_type: type[EventT_contra] | None = None,
+) -> (
+    Callable[[CallbackT[EventT_contra]], Includable[EventMeta[EventT_contra]]]
+    | Includable[EventMeta[EventT_contra]]
+):
     """
     Listen to an event. This function should be used instead of
     `hikari.GatewayBot.listen` whenever possible.
@@ -69,7 +81,7 @@ def event(
     to use type annotations.
     """
     if callback is None:
-        return partial(event, event_type=event_type)  # pyright: ignore
+        return partial(event, event_type=event_type)  # pyright: ignore[reportReturnType]
 
     if not event_type:
         event_type = next(iter(get_type_hints(callback).values()))
@@ -80,22 +92,24 @@ def event(
     if not iscoroutinefunction(callback):
         raise ValueError(f"`{callback.__name__}` must be an async function.")
 
-    def hook(includable: Includable[EventMeta[EventT]]) -> None:
+    def hook(includable: Includable[EventMeta[EventT_contra]]) -> None:
         if isinstance(includable.client.app, EventManagerAware):
             includable.client.app.event_manager.subscribe(
-                event_type=unwrap(event_type), callback=event_callback
+                event_type=unwrap(event_type),
+                callback=event_callback,
             )
         else:
             raise ValueError(
-                "Events can only be used with bots that implement `hikari.EventManagerAware`."
+                "Events can only be used with bots that implement `hikari.EventManagerAware`.",
             )
 
-    def on_remove(includable: Includable[EventMeta[EventT]]) -> None:
+    def on_remove(includable: Includable[EventMeta[EventT_contra]]) -> None:
         # if it's not `EventManagerAware`, the event could never have been
         # added in the first place.
         assert isinstance(includable.client.app, EventManagerAware)
         includable.client.app.event_manager.unsubscribe(
-            event_type=unwrap(event_type), callback=event_callback
+            event_type=unwrap(event_type),
+            callback=event_callback,
         )
 
     includable = Includable(

--- a/crescent/exceptions.py
+++ b/crescent/exceptions.py
@@ -1,21 +1,22 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Sequence
+from typing import TYPE_CHECKING, Any
 
-from crescent.typedefs import ClassCommandProto
+if TYPE_CHECKING:
+    from crescent.typedefs import ClassCommandProto
 
-__all__: Sequence[str] = (
-    "CrescentException",
-    "ConverterExceptions",
-    "ConverterExceptionMeta",
+__all__ = (
     "AlreadyRegisteredError",
-    "PluginAlreadyLoadedError",
+    "ConverterExceptionMeta",
+    "ConverterExceptions",
+    "CrescentException",
     "PermissionsError",
+    "PluginAlreadyLoadedError",
 )
 
 
-class CrescentException(Exception):
+class CrescentException(Exception):  # noqa: N818
     """Base Exception for all exceptions Crescent throws"""
 
 

--- a/crescent/ext/cooldowns/__init__.py
+++ b/crescent/ext/cooldowns/__init__.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from datetime import timedelta
-from typing import Any, Awaitable, Callable, Optional
-
-from hikari import Snowflake
+from typing import TYPE_CHECKING, Any
 
 from crescent import Context, HookResult
 
-__all__ = ("CooldownCallbackT", "BucketCallbackT", "cooldown")
+if TYPE_CHECKING:
+    from hikari import Snowflake
 
-CooldownCallbackT = Callable[[Context, timedelta], Awaitable[Optional[HookResult]]]
+__all__ = ("BucketCallbackT", "CooldownCallbackT", "cooldown")
+
+CooldownCallbackT = Callable[[Context, timedelta], Awaitable[HookResult | None]]
 BucketCallbackT = Callable[[Context], Any]
 
 
@@ -19,12 +21,10 @@ def _default_bucket(ctx: Context) -> Snowflake:
 
 async def _default_callback(ctx: Context, retry: timedelta) -> None:
     seconds = round(retry.total_seconds())
-    if seconds <= 1:
-        message = "1 second"
-    else:
-        message = f"{seconds} seconds"
+    message = "1 second" if seconds <= 1 else f"{seconds} seconds"
     await ctx.respond(
-        f"You're using this command too much! Try again in {message}.", ephemeral=True
+        f"You're using this command too much! Try again in {message}.",
+        ephemeral=True,
     )
 
 
@@ -51,10 +51,10 @@ def cooldown(
 
     try:
         from floodgate import FixedMapping
-    except ImportError:
+    except ImportError as exc:
         raise ModuleNotFoundError(
-            "`hikari-crescent[cooldowns]` must be installed to use `crescent.ext.cooldowns`."
-        )
+            "`hikari-crescent[cooldowns]` must be installed to use `crescent.ext.cooldowns`.",
+        ) from exc
 
     cooldown: FixedMapping[Any] = FixedMapping(period=period, capacity=capacity)
 

--- a/crescent/ext/locales/__init__.py
+++ b/crescent/ext/locales/__init__.py
@@ -1,23 +1,21 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
-from typing import Sequence
 
 import hikari
-
 from crescent import LocaleBuilder
 
 try:
-    import i18n as i18n_  # type: ignore
+    import i18n as i18n_  # type: ignore[import-untyped]
 except ImportError:
     i18n_ = None
 
 
-__all__: Sequence[str] = ("i18n", "LocaleMap")
+__all__ = ("LocaleMap", "i18n")
 
 
 def _translate(key: str, *, locale: str | None = None) -> str:
-    return i18n_.t(key, locale=locale)  # type: ignore
+    return i18n_.t(key, locale=locale)  # type: ignore  # noqa: PGH003
 
 
 class i18n(LocaleBuilder):

--- a/crescent/ext/tasks/__init__.py
+++ b/crescent/ext/tasks/__init__.py
@@ -1,15 +1,15 @@
-from typing import Sequence
+from __future__ import annotations
 
-from crescent.ext.tasks.cron import *
-from crescent.ext.tasks.loop import *
-from crescent.ext.tasks.task import *
+from crescent.ext.tasks.cron import Cronjob, cronjob
+from crescent.ext.tasks.loop import Loop, loop
+from crescent.ext.tasks.task import Task, TaskCallbackT, TaskError
 
-__all__: Sequence[str] = (
-    "cronjob",
-    "loop",
-    "TaskCallbackT",
+__all__ = (
     "Cronjob",
     "Loop",
     "Task",
+    "TaskCallbackT",
     "TaskError",
+    "cronjob",
+    "loop",
 )

--- a/crescent/ext/tasks/cron.py
+++ b/crescent/ext/tasks/cron.py
@@ -1,22 +1,27 @@
-from datetime import datetime
-from typing import Callable, Sequence
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 from crescent.ext.tasks.task import Task, TaskCallbackT
 from crescent.internal import Includable
 
-__all__: Sequence[str] = ("cronjob", "Cronjob")
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+__all__ = ("Cronjob", "cronjob")
 
 
 class Cronjob(Task):
     def __init__(self, cron: str, callback: TaskCallbackT, *, first_loop: bool) -> None:
         try:
             from croniter import croniter
-        except ImportError:
+        except ImportError as exc:
             raise ModuleNotFoundError(
-                "`hikari-crescent[cron]` must be installed to use `cooldowns.cronjob`."
-            )
+                "`hikari-crescent[cron]` must be installed to use `cooldowns.cronjob`.",
+            ) from exc
 
-        self.cron: croniter = croniter(cron, datetime.now())
+        self.cron: croniter = croniter(cron, datetime.now(tz=timezone.utc))
         self.first_loop: bool = first_loop
 
         super().__init__(callback)
@@ -26,7 +31,7 @@ class Cronjob(Task):
             return 0
 
         call_next_at: datetime = self.cron.get_next(datetime)
-        time_to_next = call_next_at - datetime.now()
+        time_to_next = call_next_at - datetime.now(tz=timezone.utc)
         return time_to_next.total_seconds()
 
     def _call_next(self) -> None:
@@ -35,7 +40,10 @@ class Cronjob(Task):
 
 
 def cronjob(
-    cron: str, /, on_startup: bool = False
+    cron: str,
+    /,
+    *,
+    on_startup: bool = False,
 ) -> Callable[[TaskCallbackT], Includable[Cronjob]]:
     """
     Run a task at the time specified by the cron schedule expression.

--- a/crescent/ext/tasks/loop.py
+++ b/crescent/ext/tasks/loop.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import timedelta as _timedelta
-from typing import Callable, Sequence, overload
+from typing import overload
 
 from crescent.ext.tasks.task import Task, TaskCallbackT
 from crescent.internal import Includable
 
-__all__: Sequence[str] = ("loop", "Loop")
+__all__ = ("Loop", "loop")
 
 
 class Loop(Task):
@@ -30,7 +31,11 @@ class Loop(Task):
 
     @overload
     def set_interval(
-        self, *, hours: int = ..., minutes: int = ..., seconds: int = ...
+        self,
+        *,
+        hours: int = ...,
+        minutes: int = ...,
+        seconds: int = ...,
     ) -> None: ...
 
     @overload
@@ -80,20 +85,24 @@ class Loop(Task):
             self.start()
 
 
-retT = Callable[[TaskCallbackT], Includable[Loop]]
+LoopFactoryT = Callable[[TaskCallbackT], Includable[Loop]]
 
 
 @overload
-def loop(*, hours: int = ..., minutes: int = ..., seconds: int = ...) -> retT: ...
+def loop(*, hours: int = ..., minutes: int = ..., seconds: int = ...) -> LoopFactoryT: ...
 
 
 @overload
-def loop(timedelta: _timedelta, /) -> retT: ...
+def loop(timedelta: _timedelta, /) -> LoopFactoryT: ...
 
 
 def loop(
-    timedelta: _timedelta | None = None, *, hours: int = 0, minutes: int = 0, seconds: int = 0
-) -> retT:
+    timedelta: _timedelta | None = None,
+    *,
+    hours: int = 0,
+    minutes: int = 0,
+    seconds: int = 0,
+) -> LoopFactoryT:
     """
     Run a callback when the bot is started and every time the specified
     time interval has passed.

--- a/crescent/ext/tasks/task.py
+++ b/crescent/ext/tasks/task.py
@@ -2,19 +2,21 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from asyncio import TimerHandle, get_running_loop
-from typing import TYPE_CHECKING, Awaitable, Callable, Sequence, TypeVar
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, TypeVar
 
-from crescent.client import Client
 from crescent.exceptions import CrescentException
-from crescent.internal.includable import Includable
 from crescent.utils import create_task
 
 if TYPE_CHECKING:
     from asyncio import AbstractEventLoop
 
+    from crescent.client import Client
+    from crescent.internal.includable import Includable
+
 TaskCallbackT = Callable[[], Awaitable[None]]
 
-__all__: Sequence[str] = ("TaskCallbackT", "Task", "TaskError")
+__all__ = ("Task", "TaskCallbackT", "TaskError")
 
 
 class TaskError(CrescentException): ...
@@ -31,7 +33,7 @@ class Task(ABC):
         if self.running:
             raise TaskError("Task is already running.")
 
-        assert self.client
+        assert self.client is not None
         self.client._run_future(self._start_inner())
 
     async def _start_inner(self) -> None:

--- a/crescent/hooks.py
+++ b/crescent/hooks.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Generic, Sequence, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, overload
 
 from hikari import Event
 
@@ -9,13 +9,15 @@ from crescent.events import EventMeta
 from crescent.internal.app_command import AppCommandMeta
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from crescent.internal.includable import Includable
     from crescent.typedefs import CommandHookCallbackT, EventHookCallbackT
 
 IncludableT = TypeVar("IncludableT")
-EventT = TypeVar("EventT", bound=Event, contravariant=True)
+EventT_contra = TypeVar("EventT_contra", bound=Event, contravariant=True)
 
-__all__: Sequence[str] = ("HookResult", "hook")
+__all__ = ("HookResult", "hook")
 
 
 @dataclass
@@ -37,12 +39,14 @@ def hook(*callbacks: CommandHookCallbackT, after: bool = False) -> _Hook[AppComm
 
 @overload
 def hook(
-    *callbacks: EventHookCallbackT[EventT], after: bool = False
-) -> _Hook[EventMeta[EventT]]: ...
+    *callbacks: EventHookCallbackT[EventT_contra],
+    after: bool = False,
+) -> _Hook[EventMeta[EventT_contra]]: ...
 
 
 def hook(
-    *callbacks: CommandHookCallbackT | EventHookCallbackT[EventT], after: bool = False
+    *callbacks: CommandHookCallbackT | EventHookCallbackT[EventT_contra],
+    after: bool = False,
 ) -> _Hook[Any]:
     # TODO: Example for events
     """
@@ -63,23 +67,25 @@ def hook(
     Args:
         after: If true, run this hook after the command or event has completed.
     """
-    return _Hook(callbacks, after)
+    return _Hook(callbacks, after=after)
 
 
 class _Hook(Generic[IncludableT]):
-    def __init__(self, callbacks: Any, after: bool):
+    def __init__(self, callbacks: Any, *, after: bool) -> None:
         self.callbacks = callbacks
         self.after = after
 
     @overload
     def __call__(
-        self: _Hook[AppCommandMeta], obj: Includable[AppCommandMeta]
+        self: _Hook[AppCommandMeta],
+        obj: Includable[AppCommandMeta],
     ) -> Includable[AppCommandMeta]: ...
 
     @overload
     def __call__(
-        self: _Hook[EventMeta[EventT]], obj: Includable[EventMeta[EventT]]
-    ) -> Includable[EventMeta[EventT]]: ...
+        self: _Hook[EventMeta[EventT_contra]],
+        obj: Includable[EventMeta[EventT_contra]],
+    ) -> Includable[EventMeta[EventT_contra]]: ...
 
     def __call__(self, obj: Includable[Any]) -> Includable[Any]:
         if isinstance(obj.metadata, AppCommandMeta):

--- a/crescent/internal/__init__.py
+++ b/crescent/internal/__init__.py
@@ -1,15 +1,14 @@
-from typing import Sequence
+from __future__ import annotations
 
-from .app_command import *
-from .handle_resp import *
-from .includable import *
-from .registry import *
+from .app_command import AppCommand, AppCommandMeta, Unique
+from .includable import Includable
+from .registry import CommandHandler, register_command
 
-__all__: Sequence[str] = (
-    "AppCommandMeta",
+__all__ = (
     "AppCommand",
-    "Unique",
-    "Includable",
-    "register_command",
+    "AppCommandMeta",
     "CommandHandler",
+    "Includable",
+    "Unique",
+    "register_command",
 )

--- a/crescent/internal/app_command.py
+++ b/crescent/internal/app_command.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Iterable, TypeVar
+from typing import TYPE_CHECKING, Any
 
 from hikari import (
     UNDEFINED,
@@ -12,21 +12,22 @@ from hikari import (
     SlashCommand,
     Snowflakeish,
 )
-from hikari.api import EntityFactory
 
 from crescent.locale import LocaleBuilder, str_or_build_locale
 from crescent.utils import add_hooks
 
 if TYPE_CHECKING:
-    from typing import Any, Sequence, Type
+    from collections.abc import Iterable, Sequence
 
     from hikari import CommandType, Snowflake, UndefinedOr, UndefinedType
+    from hikari.api import EntityFactory
 
     from crescent.commands.groups import Group, SubGroup
     from crescent.internal.includable import Includable
     from crescent.typedefs import AutocompleteCallbackT, CommandCallbackT, CommandHookCallbackT
 
-    Self = TypeVar("Self")
+
+__all__ = ("AppCommand", "AppCommandMeta")
 
 
 @dataclass(frozen=True)
@@ -38,7 +39,7 @@ class Unique:
     sub_group: str | None
 
     @classmethod
-    def from_meta_struct(cls: Type[Unique], command: Includable[AppCommandMeta]) -> Unique:
+    def from_meta_struct(cls, command: Includable[AppCommandMeta]) -> Unique:
         return cls(
             name=str_or_build_locale(command.metadata.app_command.name)[0],
             type=command.metadata.app_command.type,
@@ -52,7 +53,7 @@ class Unique:
         )
 
     @classmethod
-    def from_app_command_meta(cls: Type[Unique], command: AppCommandMeta) -> Unique:
+    def from_app_command_meta(cls, command: AppCommandMeta) -> Unique:
         return cls(
             name=str_or_build_locale(command.app_command.name)[0],
             type=command.app_command.type,
@@ -62,9 +63,6 @@ class Unique:
             if command.sub_group
             else None,
         )
-
-
-__all__: Sequence[str] = ("AppCommandMeta", "AppCommand")
 
 
 @dataclass
@@ -97,7 +95,7 @@ class AppCommand:
                     description != other.description,
                     (self.options or None) != (other.options or None),
                     description_localizations != other.description_localizations,
-                )
+                ),
             ):
                 return False
 
@@ -111,8 +109,8 @@ class AppCommand:
                 name == other.name,
                 name_localizations == other.name_localizations,
                 context_types == set(other.context_types),
-                self.build_default_member_perms() or 0 == other.default_member_permissions,
-            )
+                other.default_member_permissions == self.build_default_member_perms() or 0,
+            ),
         )
 
     def build_default_member_perms(self) -> Permissions | None:
@@ -161,7 +159,11 @@ class AppCommandMeta:
     after_hooks: list[CommandHookCallbackT] = field(default_factory=list)  # pyright: ignore[reportUnknownVariableType]
 
     def add_hooks(
-        self, hooks: Sequence[CommandHookCallbackT], prepend: bool = False, *, after: bool
+        self,
+        hooks: Sequence[CommandHookCallbackT],
+        *,
+        prepend: bool = False,
+        after: bool,
     ) -> None:
         add_hooks(self.hooks, self.after_hooks, hooks, prepend=prepend, after=after)
 

--- a/crescent/internal/handle_resp.py
+++ b/crescent/internal/handle_resp.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from asyncio import Future
 from contextlib import suppress
 from logging import getLogger
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from hikari import (
     AutocompleteInteraction,
@@ -15,7 +14,6 @@ from hikari import (
     OptionType,
     Snowflake,
 )
-from hikari.api import InteractionResponseBuilder
 from hikari.impl import AutocompleteChoiceBuilder
 
 from crescent.context import AutocompleteContext, Context
@@ -24,9 +22,11 @@ from crescent.mentionable import Mentionable
 from crescent.utils import unwrap
 
 if TYPE_CHECKING:
-    from typing import Any, Sequence
+    from asyncio import Future
+    from collections.abc import Sequence
 
     from hikari import CommandInteractionOption, Message, PartialInteraction, User
+    from hikari.api import InteractionResponseBuilder
 
     from crescent.client import Client
     from crescent.internal import AppCommandMeta, Includable
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 
 _log = getLogger(__name__)
 
-__all__: Sequence[str] = ("handle_resp",)
+__all__ = ("handle_resp",)
 
 
 async def handle_resp(
@@ -43,20 +43,25 @@ async def handle_resp(
     interaction: PartialInteraction,
     future: Future[InteractionResponseBuilder] | None,
 ) -> None:
-    if not isinstance(interaction, (CommandInteraction, AutocompleteInteraction)):
+    if not isinstance(interaction, CommandInteraction | AutocompleteInteraction):
         return
 
     command_name, group, sub_group, _ = _get_crescent_command_data(interaction)
 
     command = _get_command(
-        client, command_name, interaction.command_type, interaction.guild_id, group, sub_group
+        client,
+        command_name,
+        interaction.command_type,
+        interaction.guild_id,
+        group,
+        sub_group,
     )
 
     if not command:
         if not client.allow_unknown_interactions:
             _log.warning(
                 f"Handler for command `{command_name}` does not exist locally. (If this is"
-                " intended, add `allow_unknown_interactions=True` to the Client's constructor.)"
+                " intended, add `allow_unknown_interactions=True` to the Client's constructor.)",
             )
         return
 
@@ -94,7 +99,8 @@ async def _handle_slash_resp(command: Includable[AppCommandMeta], ctx: Context) 
 
 
 async def _handle_autocomplete_resp(
-    command: Includable[AppCommandMeta], ctx: AutocompleteContext
+    command: Includable[AppCommandMeta],
+    ctx: AutocompleteContext,
 ) -> None:
     if not command.metadata.autocomplete:
         return
@@ -113,10 +119,14 @@ async def _handle_autocomplete_resp(
             await ctx.interaction.create_response(choices)
     except Exception as exc:
         handled = await command.client._autocomplete_error_handler.try_handle(
-            exc, [exc, ctx, option]
+            exc,
+            [exc, ctx, option],
         )
         await command.client.on_crescent_autocomplete_error(
-            exc, ctx.into(AutocompleteContext), option, handled
+            exc,
+            ctx.into(AutocompleteContext),
+            option,
+            handled,
         )
 
 
@@ -136,12 +146,17 @@ def _get_option_recursive(
 def _get_command(
     client: Client,
     name: str,
-    type: CommandType | int,
+    command_type: CommandType | int,
     guild_id: Snowflake | None,
     group: str | None,
     sub_group: str | None,
 ) -> Includable[AppCommandMeta] | None:
-    kwargs: dict[str, Any] = dict(name=name, type=type, group=group, sub_group=sub_group)
+    kwargs: dict[str, Any] = {
+        "name": name,
+        "type": command_type,
+        "group": group,
+        "sub_group": sub_group,
+    }
 
     with suppress(KeyError):
         return client._command_handler._get(Unique(guild_id=guild_id, **kwargs))
@@ -189,12 +204,16 @@ def _get_crescent_command_data(
             options = unwrap(option.options)[0].options
 
     return CrescentCommandData(
-        command_name=command_name, group=group, sub_group=sub_group, options=options
+        command_name=command_name,
+        group=group,
+        sub_group=sub_group,
+        options=options,
     )
 
 
 def _context_from_interaction_resp(
-    client: Client, interaction: CommandInteraction | AutocompleteInteraction
+    client: Client,
+    interaction: CommandInteraction | AutocompleteInteraction,
 ) -> Context:
     command_name, group, sub_group, options = _get_crescent_command_data(interaction)
 
@@ -257,7 +276,8 @@ def _get_resolved(interaction: CommandInteraction, option_type: int) -> Any | No
 
 
 def _extract_value(
-    option: CommandInteractionOption, interaction: CommandInteraction | AutocompleteInteraction
+    option: CommandInteractionOption,
+    interaction: CommandInteraction | AutocompleteInteraction,
 ) -> Any:
     # `option.value` is guaranteed to have a value because this is not a command group.
     assert option.value is not None
@@ -288,5 +308,5 @@ def _resolved_data_to_kwargs(interaction: CommandInteraction) -> dict[str, Messa
         return {"user": next(iter(interaction.resolved.users.values()))}
 
     raise AttributeError(
-        "interaction.resolved did not have property `messages`, `members`, or `users`"
+        "interaction.resolved did not have property `messages`, `members`, or `users`",
     )

--- a/crescent/internal/includable.py
+++ b/crescent/internal/includable.py
@@ -1,29 +1,29 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from crescent.utils.options import unwrap
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Sequence
+    from collections.abc import Callable
 
     from crescent.client import Client
 
-T = TypeVar("T", contravariant=True)
+T_contra = TypeVar("T_contra", contravariant=True)
 
-__all__: Sequence[str] = ("Includable",)
+__all__ = ("Includable",)
 
 
 @dataclass
-class Includable(Generic[T]):
-    metadata: T
+class Includable(Generic[T_contra]):
+    metadata: T_contra
 
     manager: Any | None = None
     _client: Client | None = None
 
-    client_set_hooks: list[Callable[[Includable[T]], None]] = field(default_factory=list)  # pyright: ignore[reportUnknownVariableType]
-    plugin_unload_hooks: list[Callable[[Includable[T]], None]] = field(default_factory=list)  # pyright: ignore[reportUnknownVariableType]
+    client_set_hooks: list[Callable[[Includable[T_contra]], None]] = field(default_factory=list)  # pyright: ignore[reportUnknownVariableType]
+    plugin_unload_hooks: list[Callable[[Includable[T_contra]], None]] = field(default_factory=list)  # pyright: ignore[reportUnknownVariableType]
 
     @property
     def client(self) -> Client:

--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -4,7 +4,7 @@ from asyncio import gather
 from collections import defaultdict
 from inspect import iscoroutinefunction
 from logging import getLogger
-from typing import TYPE_CHECKING, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
 from hikari import (
     UNDEFINED,
@@ -27,14 +27,12 @@ from crescent.locale import LocaleBuilder, str_or_build_locale
 from crescent.utils import gather_iter, unwrap
 
 if TYPE_CHECKING:
-    from typing import Any, Awaitable, Callable, DefaultDict, Iterable, Sequence
+    from collections.abc import Awaitable, Callable, Iterable, Sequence
 
     from hikari import PartialGuild, Snowflakeish, SnowflakeishOr
 
     from crescent.client import Client
     from crescent.typedefs import AutocompleteCallbackT, CommandCallbackT
-
-    T = TypeVar("T", bound="Callable[..., Awaitable[Any]]")
 
 _log = getLogger(__name__)
 
@@ -57,9 +55,11 @@ def register_command(
     options: Sequence[CommandOption] | None = None,
     default_member_permissions: UndefinedType | int | Permissions = UNDEFINED,
     context_types: UndefinedOr[Iterable[ApplicationContextType]] = UNDEFINED,
-    autocomplete: dict[str, AutocompleteCallbackT[Any]] = {},
+    autocomplete: dict[str, AutocompleteCallbackT[Any]] | None = None,
     nsfw: bool | None = None,
 ) -> Includable[AppCommandMeta]:
+    if autocomplete is None:
+        autocomplete = {}
     if not iscoroutinefunction(callback):
         raise ValueError(f"`{callback.__name__}` must be an async function.")
 
@@ -90,7 +90,7 @@ _E = TypeVar("_E", bound="Callable[..., Awaitable[Any]]")
 
 
 class ErrorHandler(Generic[_E]):
-    __slots__: Sequence[str] = ("bot", "registry", "subclass_registry", "supports_custom_ctx")
+    __slots__ = ("bot", "registry", "subclass_registry", "supports_custom_ctx")
 
     def __init__(self) -> None:
         self.registry: dict[type[Exception], Includable[_E]] = {}
@@ -99,9 +99,9 @@ class ErrorHandler(Generic[_E]):
     def register(self, includable: Includable[_E], exc: type[Exception]) -> None:
         if reg_includable := self.registry.get(exc):
             raise AlreadyRegisteredError(
-                f"`{getattr(includable.metadata, '__name__')}` can not catch `{exc.__name__}`."
+                f"`{includable.metadata.__name__}` can not catch `{exc.__name__}`."
                 f" `{exc.__name__}` is already registered to"
-                f" `{reg_includable.metadata.__name__}`."
+                f" `{reg_includable.metadata.__name__}`.",
             )
 
         self.registry[exc] = includable
@@ -131,7 +131,7 @@ class ErrorHandler(Generic[_E]):
 
 
 class CommandHandler:
-    __slots__: Sequence[str] = ("_client", "_guilds", "_application_id", "_registry")
+    __slots__ = ("_application_id", "_client", "_guilds", "_registry")
 
     def __init__(self, client: Client, guilds: Sequence[Snowflakeish]) -> None:
         self._client: Client = client
@@ -198,11 +198,9 @@ class CommandHandler:
 
                 children = cast("list[CommandOption]", unwrap(built_commands[key].options))
 
-                name, name_localizations = str_or_build_locale(
-                    unwrap(command.metadata.sub_group).name
-                )
+                name, name_localizations = str_or_build_locale(command.metadata.sub_group.name)
                 description, description_localizations = str_or_build_locale(
-                    unwrap(command.metadata.sub_group).description or "No Description"
+                    command.metadata.sub_group.description or "No Description",
                 )
 
                 sub_command_group = CommandOption(
@@ -231,7 +229,7 @@ class CommandHandler:
                 name, name_localizations = str_or_build_locale(command.metadata.app_command.name)
                 assert command.metadata.app_command.description
                 description, description_localizations = str_or_build_locale(
-                    command.metadata.app_command.description
+                    command.metadata.app_command.description,
                 )
 
                 cast("list[CommandOption]", sub_command_group.options).append(
@@ -243,7 +241,7 @@ class CommandHandler:
                         type=OptionType.SUB_COMMAND,
                         options=command.metadata.app_command.options,
                         is_required=False,
-                    )
+                    ),
                 )
 
             elif command.metadata.group:
@@ -268,7 +266,7 @@ class CommandHandler:
                 if key not in built_commands:
                     built_commands[key] = AppCommand(
                         name=command.metadata.group.name,
-                        description=unwrap(command.metadata.group).description or "No Description",
+                        description=command.metadata.group.description or "No Description",
                         type=command.metadata.app_command.type,
                         guild_id=command.metadata.app_command.guild_id,
                         options=[],
@@ -282,7 +280,7 @@ class CommandHandler:
                 name, name_localizations = str_or_build_locale(command.metadata.app_command.name)
                 assert command.metadata.app_command.description
                 description, description_localizations = str_or_build_locale(
-                    command.metadata.app_command.description
+                    command.metadata.app_command.description,
                 )
 
                 cast("list[CommandOption]", built_commands[key].options).append(
@@ -294,7 +292,7 @@ class CommandHandler:
                         type=command.metadata.app_command.type,
                         options=command.metadata.app_command.options,
                         is_required=False,
-                    )
+                    ),
                 )
 
             else:
@@ -303,14 +301,16 @@ class CommandHandler:
         return tuple(built_commands.values())
 
     async def __post_application_commands(
-        self, commands: Sequence[AppCommand], guild: UndefinedOr[Snowflakeish]
+        self,
+        commands: Sequence[AppCommand],
+        guild: UndefinedOr[Snowflakeish],
     ) -> None:
         try:
             if self._application_id is None:
                 raise AttributeError("Client `application_id` is not defined")
 
             existing_commands = await self._client.app.rest.fetch_application_commands(
-                application=self._application_id
+                application=self._application_id,
             )
 
             def exists(command: AppCommand) -> bool:
@@ -332,14 +332,13 @@ class CommandHandler:
                 else:
                     _log.info("No global application commands need to be updated.")
                 return
-            else:
-                _log.info(f"Outdated commands: {', '.join(missing)}")
-                _log.info(f"Already updated: {', '.join(updated)}")
+            _log.info(f"Outdated commands: {', '.join(missing)}")
+            _log.info(f"Already updated: {', '.join(updated)}")
 
             await self._client.app.rest.set_application_commands(
                 application=self._application_id,
                 # The only method that is called has been implemented.
-                commands=commands,  # type: ignore
+                commands=commands,  # type: ignore[arg-type]
                 guild=guild,
             )
             if guild:
@@ -392,10 +391,7 @@ class CommandHandler:
             await self._client.app.rest.set_application_commands(self._application_id, ())
 
         guilds_to_purge: Iterable[PartialGuild | Snowflake | int]
-        if purge_everything:
-            guilds_to_purge = {*guilds, *self._guilds}
-        else:
-            guilds_to_purge = guilds
+        guilds_to_purge = {*guilds, *self._guilds} if purge_everything else guilds
 
         for guild in guilds_to_purge:
             await self._client.app.rest.set_application_commands(self._application_id, (), guild)
@@ -405,7 +401,7 @@ class CommandHandler:
 
         commands = self.__build_commands()
 
-        command_guilds: DefaultDict[Snowflakeish, list[AppCommand]] = defaultdict(list)
+        command_guilds: defaultdict[Snowflakeish, list[AppCommand]] = defaultdict(list)
         global_commands: list[AppCommand] = []
 
         for command in commands:
@@ -428,7 +424,9 @@ class CommandHandler:
             ),
             gather_iter(
                 self._client.app.rest.set_application_commands(
-                    application=self._application_id, commands=[], guild=guild
+                    application=self._application_id,
+                    commands=[],
+                    guild=guild,
                 )
                 for guild in guilds
             ),

--- a/crescent/locale.py
+++ b/crescent/locale.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Mapping, Sequence
+from typing import TYPE_CHECKING
 
-__all__: Sequence[str] = ("LocaleBuilder", "str_or_build_locale")
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+__all__ = ("LocaleBuilder", "str_or_build_locale")
 
 
 class LocaleBuilder(ABC):
@@ -19,7 +22,7 @@ class LocaleBuilder(ABC):
         language codes to strings.
 
         [Discord API Docs Localization.](https://discord.com/developers/docs/interactions/application-commands#localization)
-        """  # noqa: E501
+        """
 
     @property
     @abstractmethod
@@ -30,5 +33,4 @@ class LocaleBuilder(ABC):
 def str_or_build_locale(string_or_locale: str | LocaleBuilder) -> tuple[str, Mapping[str, str]]:
     if isinstance(string_or_locale, LocaleBuilder):
         return (string_or_locale.fallback, string_or_locale.build())
-    else:
-        return (string_or_locale, {})
+    return (string_or_locale, {})

--- a/crescent/mentionable.py
+++ b/crescent/mentionable.py
@@ -4,14 +4,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Sequence
-
     from hikari import CommandInteraction, Role, User
 
-__all__: Sequence[str] = ("Mentionable",)
+__all__ = ("Mentionable",)
 
 
-@dataclass
+@dataclass(slots=True)
 class Mentionable:
     """
     Represent's discord's mentionable type. A mentionable can be a User or Role.
@@ -28,8 +26,6 @@ class Mentionable:
             role = mentionable.unwrap_role()
     ```
     """
-
-    __slots__ = ("user", "role")
 
     user: User | None
     role: Role | None

--- a/crescent/plugin.py
+++ b/crescent/plugin.py
@@ -3,20 +3,19 @@ from __future__ import annotations
 from importlib import import_module, reload
 from logging import getLogger
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Generic, Literal, Sequence, TypeVar, cast, overload
-
-from hikari import Event
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast, overload
 
 from crescent.exceptions import PluginAlreadyLoadedError
 from crescent.hooks import add_hooks
-from crescent.internal.includable import Includable
-from crescent.typedefs import EventHookCallbackT
 
 if TYPE_CHECKING:
-    from crescent.client import Client, GatewayTraits, RESTTraits
-    from crescent.typedefs import CommandHookCallbackT, PluginCallbackT
+    from hikari import Event
 
-__all__: Sequence[str] = ("PluginManager", "Plugin")
+    from crescent.client import Client, GatewayTraits, RESTTraits
+    from crescent.internal.includable import Includable
+    from crescent.typedefs import CommandHookCallbackT, EventHookCallbackT, PluginCallbackT
+
+__all__ = ("Plugin", "PluginManager")
 
 
 T = TypeVar("T", bound="Includable[Any]")
@@ -46,21 +45,37 @@ class PluginManager:
 
     @overload
     def load(
-        self, path: str, *, strict: Literal[True], refresh: bool = ...
+        self,
+        path: str,
+        *,
+        strict: Literal[True],
+        refresh: bool = ...,
     ) -> Plugin[Any, Any]: ...
 
     @overload
     def load(
-        self, path: str, *, strict: Literal[False], refresh: bool = ...
+        self,
+        path: str,
+        *,
+        strict: Literal[False],
+        refresh: bool = ...,
     ) -> Plugin[Any, Any] | None: ...
 
     @overload
     def load(
-        self, path: str, refresh: bool = ..., strict: bool = ...
+        self,
+        path: str,
+        *,
+        refresh: bool = ...,
+        strict: bool = ...,
     ) -> Plugin[Any, Any] | None: ...
 
     def load(
-        self, path: str, refresh: bool = False, strict: bool = True
+        self,
+        path: str,
+        *,
+        refresh: bool = False,
+        strict: bool = True,
     ) -> Plugin[Any, Any] | None:
         """Load a plugin from the module path.
 
@@ -92,7 +107,11 @@ class PluginManager:
         return plugin
 
     def load_folder(
-        self, path: str, refresh: bool = False, strict: bool = True
+        self,
+        path: str,
+        *,
+        refresh: bool = False,
+        strict: bool = True,
     ) -> list[Plugin[Any, Any]]:
         """Loads plugins from a folder.
 
@@ -135,7 +154,8 @@ class PluginManager:
 
         if not loaded_plugins:
             _LOG.warning(
-                "No plugins were loaded! Are you sure `%s` is the correct directory?", pathlib_path
+                "No plugins were loaded! Are you sure `%s` is the correct directory?",
+                pathlib_path,
             )
 
         return loaded_plugins
@@ -159,11 +179,17 @@ class PluginManager:
                 self.unload(plugin_path)
             raise e
 
-    def _add_plugin(self, path: str, plugin: Plugin[Any, Any], refresh: bool = False) -> None:
+    def _add_plugin(
+        self,
+        path: str,
+        plugin: Plugin[Any, Any],
+        *,
+        refresh: bool = False,
+    ) -> None:
         if path in self.plugins and not refresh:
             raise PluginAlreadyLoadedError(
                 f"Plugin `{path}` is already loaded."
-                " Add the kwarg `refresh=True` to the function call if this is intended."
+                " Add the kwarg `refresh=True` to the function call if this is intended.",
             )
 
         self.plugins[path] = plugin
@@ -242,19 +268,19 @@ class Plugin(Generic[BotT, ModelT]):
     def app(self) -> BotT:
         if not self._client:
             raise AttributeError("`Plugin.app` can not be accessed before the plugin is loaded.")
-        return cast(BotT, self._client.app)
+        return cast("BotT", self._client.app)
 
     @property
     def model(self) -> ModelT:
         if not self._client:
             raise AttributeError("`Plugin.model` can not be accessed before the plugin is loaded.")
-        return cast(ModelT, self._client.model)
+        return cast("ModelT", self._client.model)
 
     @property
     def client(self) -> Client:
         if not self._client:
             raise AttributeError(
-                "`Plugin.client` can not be accessed before the plugin is loaded."
+                "`Plugin.client` can not be accessed before the plugin is loaded.",
             )
         return self._client
 
@@ -290,24 +316,40 @@ class Plugin(Generic[BotT, ModelT]):
     @overload
     @classmethod
     def _from_module(
-        cls, path: str, *, strict: Literal[True], refresh: bool = ...
+        cls,
+        path: str,
+        *,
+        strict: Literal[True],
+        refresh: bool = ...,
     ) -> Plugin[BotT, ModelT]: ...
 
     @overload
     @classmethod
     def _from_module(
-        cls, path: str, *, strict: Literal[False], refresh: bool = ...
+        cls,
+        path: str,
+        *,
+        strict: Literal[False],
+        refresh: bool = ...,
     ) -> Plugin[BotT, ModelT] | None: ...
 
     @overload
     @classmethod
     def _from_module(
-        cls, path: str, refresh: bool = ..., strict: bool = ...
+        cls,
+        path: str,
+        *,
+        refresh: bool = ...,
+        strict: bool = ...,
     ) -> Plugin[BotT, ModelT] | None: ...
 
     @classmethod
     def _from_module(
-        cls, path: str, refresh: bool = False, strict: bool = True
+        cls,
+        path: str,
+        *,
+        refresh: bool = False,
+        strict: bool = True,
     ) -> Plugin[BotT, ModelT] | None:
         parents = path.split(".")
 
@@ -323,7 +365,7 @@ class Plugin(Generic[BotT, ModelT]):
             raise ValueError(
                 f"Plugin {path} has no `plugin` or `plugin` is not of type Plugin. "
                 "If you want to name your plugin something else, you have to add an "
-                "alias (plugin = YOUR_PLUGIN_NAME)."
+                "alias (plugin = YOUR_PLUGIN_NAME).",
             )
 
         return plugin

--- a/crescent/ruff.toml
+++ b/crescent/ruff.toml
@@ -1,0 +1,103 @@
+extend = "../pyproject.toml"
+
+[lint]
+select = [
+    # Correctness
+    "F",    # Pyflakes
+    "E",    # pycodestyle (errors)
+    "W",    # pycodestyle (warnings)
+    "B",    # flake8-bugbear
+    #"BLE",  # flake8-blind-except
+    #"PL",   # Pylint
+    "PGH",  # pygrep-hooks
+    "RSE",  # flake8-raise
+    "RET",  # flake8-return
+
+    # Specific pylint rules
+    "PLC0105", # type-name-incorrect-variance
+
+    # Security
+    #"S",    # flake8-bandit
+
+    # Style & formatting
+    "N",    # pep8-naming
+    "Q",    # flake8-quotes
+    "COM",  # flake8-commas
+    "I",    # isort
+    #"D",    # pydocstyle
+    #"DOC",  # pydoclint
+
+    # Simplification & modernization
+    "UP",   # pyupgrade
+    "SIM",  # flake8-simplify
+    "FURB", # refurb
+    "PIE",  # flake8-pie
+    "C4",   # flake8-comprehensions
+    "FLY",  # flynt
+    "ERA",  # eradicate
+
+    # Performance & complexity
+    "PERF", # Perflint
+    #"C90",  # mccabe
+
+    # Type annotations & checking
+    "ANN",  # flake8-annotations
+    "TC",   # flake8-type-checking
+    "FA",   # flake8-future-annotations
+    "PYI",  # flake8-pyi
+
+    # Best practices & clean code
+    "A",    # flake8-builtins
+    "ARG",  # flake8-unused-arguments
+    "FBT",  # flake8-boolean-trap
+    #"EM",   # flake8-errmsg
+    #"TRY",  # tryceratops
+    #"SLF",  # flake8-self
+    "PTH",  # flake8-use-pathlib
+    "ISC",  # flake8-implicit-str-concat
+    "ICN",  # flake8-import-conventions
+    "TID",  # flake8-tidy-imports
+    "INP",  # flake8-no-pep420
+    "SLOT", # flake8-slots
+
+    # Logging
+    "LOG",  # flake8-logging
+    "G",    # flake8-logging-format
+
+    # --- Async ---
+    "ASYNC", # flake8-async
+
+    # Development hygiene
+    "T10",  # flake8-debugger
+    "T20",  # flake8-print
+    #"FIX",  # flake8-fixme
+    #"TD",   # flake8-todos
+    "EXE",  # flake8-executable
+    "DTZ",  # flake8-datetimez
+    #"CPY",  # flake8-copyright
+
+    # Framework-specific
+    #"AIR",  # Airflow
+    #"FAST", # FastAPI
+    #"DJ",   # flake8-django
+    #"PT",   # flake8-pytest-style
+    #"NPY",  # NumPy-specific rules
+    #"PD",   # pandas-vet
+
+    # Miscellaneous
+    "YTT",  # flake8-2020
+    "INT",  # flake8-gettext
+    "RUF",  # Ruff-specific rules
+]
+ignore = [
+    "ANN401", # we allow use of Any
+]
+
+[lint.per-file-ignores]
+"ext/locales/__init__.py" = [
+    "N801", # class
+    "N815", # mixed
+]
+"locale.py" = [
+    "A005", # stdlib
+]

--- a/crescent/typedefs.py
+++ b/crescent/typedefs.py
@@ -1,15 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
-    Awaitable,
-    Callable,
-    Dict,
     Optional,
     Protocol,
-    Sequence,
-    Tuple,
     TypeVar,
     Union,
 )
@@ -29,18 +25,18 @@ if TYPE_CHECKING:
     from crescent.hooks import HookResult
     from crescent.mentionable import Mentionable
 
-__all__: Sequence[str] = (
-    "CommandCallbackT",
-    "OptionTypesT",
-    "UserCommandCallbackT",
-    "MessageCommandCallbackT",
-    "CommandOptionsT",
-    "ClassCommandProto",
-    "CommandErrorHandlerCallbackT",
+__all__ = (
     "AutocompleteCallbackT",
     "AutocompleteValueT",
+    "ClassCommandProto",
+    "CommandCallbackT",
+    "CommandErrorHandlerCallbackT",
     "CommandHookCallbackT",
+    "CommandOptionsT",
     "EventHookCallbackT",
+    "MessageCommandCallbackT",
+    "OptionTypesT",
+    "UserCommandCallbackT",
 )
 
 CommandCallbackT = Callable[["Context"], Awaitable[Any]]
@@ -48,11 +44,11 @@ UserCommandCallbackT = Callable[["Context", User], Awaitable[None]]
 MessageCommandCallbackT = Callable[["Context", Message], Awaitable[None]]
 
 OptionTypesT = Union[str, bool, int, float, PartialChannel, Role, User, "Mentionable", Attachment]
-CommandOptionsT = Dict[str, Union[OptionTypesT, User, Message]]
+CommandOptionsT = dict[str, OptionTypesT | User | Message]
 AutocompleteValueT = TypeVar("AutocompleteValueT", str, int, float)
 AutocompleteCallbackT = Callable[
     ["AutocompleteContext", AutocompleteInteractionOption],
-    Awaitable[Sequence[Tuple[str, AutocompleteValueT]]],
+    Awaitable[Sequence[tuple[str, AutocompleteValueT]]],
 ]
 
 CommandHookCallbackT = Callable[["Context"], Awaitable[Optional["HookResult"]]]
@@ -69,10 +65,11 @@ class ClassCommandProto(Protocol):
     async def callback(self, ctx: Any) -> Any: ...
 
 
-ErrorT = TypeVar("ErrorT", bound=Exception, contravariant=True)
+ErrorT_contra = TypeVar("ErrorT_contra", bound=Exception, contravariant=True)
 
-CommandErrorHandlerCallbackT = Callable[[ErrorT, Any], Awaitable[None]]
-EventErrorHandlerCallbackT = Callable[[ErrorT, Event], Awaitable[None]]
+CommandErrorHandlerCallbackT = Callable[[ErrorT_contra, Any], Awaitable[None]]
+EventErrorHandlerCallbackT = Callable[[ErrorT_contra, Event], Awaitable[None]]
 AutocompleteErrorHandlerCallbackT = Callable[
-    [ErrorT, Any, AutocompleteInteractionOption], Awaitable[None]
+    [ErrorT_contra, Any, AutocompleteInteractionOption],
+    Awaitable[None],
 ]

--- a/crescent/utils/__init__.py
+++ b/crescent/utils/__init__.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
-from typing import Sequence
+from crescent.utils.any_issubclass import any_issubclass
+from crescent.utils.gather_iter import gather_iter
+from crescent.utils.hooks import add_hooks
+from crescent.utils.options import map_or, unwrap
+from crescent.utils.tasks import create_task
 
-from crescent.utils.any_issubclass import *
-from crescent.utils.gather_iter import *
-from crescent.utils.hooks import *
-from crescent.utils.options import *
-from crescent.utils.tasks import *
-
-__all__: Sequence[str] = (
+__all__ = (
     "add_hooks",
     "any_issubclass",
-    "gather_iter",
-    "unwrap",
-    "map_or",
     "create_task",
+    "gather_iter",
+    "map_or",
+    "unwrap",
 )

--- a/crescent/utils/any_issubclass.py
+++ b/crescent/utils/any_issubclass.py
@@ -1,7 +1,9 @@
-from inspect import isclass
-from typing import Any, Sequence
+from __future__ import annotations
 
-__all__: Sequence[str] = ("any_issubclass",)
+from inspect import isclass
+from typing import Any
+
+__all__ = ("any_issubclass",)
 
 
 def any_issubclass(obj: Any, cls: type) -> bool:

--- a/crescent/utils/gather_iter.py
+++ b/crescent/utils/gather_iter.py
@@ -1,7 +1,12 @@
-from asyncio import gather
-from typing import Awaitable, Iterable, Sequence, TypeVar
+from __future__ import annotations
 
-__all__: Sequence[str] = ("gather_iter",)
+from asyncio import gather
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Iterable
+
+__all__ = ("gather_iter",)
 
 
 T = TypeVar("T")

--- a/crescent/utils/hooks.py
+++ b/crescent/utils/hooks.py
@@ -1,14 +1,22 @@
 from __future__ import annotations
 
-from typing import Sequence, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
-__all__: Sequence[str] = ("add_hooks",)
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+__all__ = ("add_hooks",)
 
 T = TypeVar("T")
 
 
 def add_hooks(
-    hooks: list[T], after_hooks: list[T], hooks_to_add: Sequence[T], *, prepend: bool, after: bool
+    hooks: list[T],
+    after_hooks: list[T],
+    hooks_to_add: Sequence[T],
+    *,
+    prepend: bool,
+    after: bool,
 ) -> None:
     def extend_or_prepend(list_to_edit: list[T]) -> None:
         if prepend:

--- a/crescent/utils/options.py
+++ b/crescent/utils/options.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from typing import Callable, Sequence, TypeVar, overload
+from typing import TYPE_CHECKING, TypeVar, overload
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 T = TypeVar("T")
 U = TypeVar("U")
 V = TypeVar("V")
 
-__all__: Sequence[str] = ("unwrap", "map_or")
+__all__ = ("map_or", "unwrap")
 
 
 def unwrap(o: T | None) -> T:

--- a/crescent/utils/tasks.py
+++ b/crescent/utils/tasks.py
@@ -2,17 +2,20 @@ from __future__ import annotations
 
 from asyncio import Task
 from asyncio import create_task as _create_task
-from typing import Any, Awaitable, Coroutine, Sequence, Set, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
-__all__: Sequence[str] = ("create_task",)
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Coroutine
+
+__all__ = ("create_task",)
 
 T = TypeVar("T")
 
-_background_tasks: Set[Any] = set()
+_background_tasks: set[Any] = set()
 
 
 def create_task(_task: Coroutine[Any, Any, T] | Awaitable[T]) -> Task[T]:
-    task: Task[Any] = _create_task(_task)  # type: ignore
+    task: Task[Any] = _create_task(_task)  # type: ignore[arg-type]
 
     _background_tasks.add(task)
     task.add_done_callback(_background_tasks.remove)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -77,6 +77,7 @@ Copy this code into a python file, and run with `python filename.py`.
     ```python
     import crescent
     import hikari
+    from crescent import options
 
     bot = hikari.GatewayBot("YOUR_TOKEN")
     client = crescent.Client(bot)
@@ -84,7 +85,7 @@ Copy this code into a python file, and run with `python filename.py`.
     @client.include
     @crescent.command(name="say")
     class Say:
-        word = crescent.option(str, "The word to say")
+        word = options.string("The word to say")
 
         async def callback(self, ctx: crescent.Context) -> None:
             await ctx.respond(self.word)
@@ -97,6 +98,7 @@ Copy this code into a python file, and run with `python filename.py`.
     ```python
     import crescent
     import hikari
+    from crescent import options
 
     bot = hikari.RESTBot("YOUR_TOKEN")
     client = crescent.Client(bot)
@@ -104,7 +106,7 @@ Copy this code into a python file, and run with `python filename.py`.
     @client.include
     @crescent.command(name="say")
     class Say:
-        word = crescent.option(str, "The word to say")
+        word = options.string("The word to say")
 
         async def callback(self, ctx: crescent.Context) -> None:
             await ctx.respond(self.word)

--- a/docs/guides/commands.md
+++ b/docs/guides/commands.md
@@ -93,24 +93,23 @@ def my_function(argument: SomeType) -> None:
 
 ### Adding Options
 
-Options are added by adding class-attrs to the class.
+Options are added by assigning builders from `crescent.options` to class attributes.
 
 ```python
+from crescent import options
+
 @client.include
 @crescent.command(name="say")
 class SayCommand:
-# The name of the command option
-#    \/
-    word = crescent.option(str)
-#                           /\
-# The type of the command option
+    # The attribute name becomes the option name by default.
+    word = options.string("The word to say")
 
     async def callback(self, ctx: crescent.Context) -> None:
-        # options are accessed attributes on the class
+        # Options are accessed as attributes on the class instance.
         await ctx.respond(self.word)
 ```
 
-Crescent's option syntax is type safe. This means that commands will
+Crescent's option builder syntax is type safe. This means that commands will
 seamlessly work with typecheckers like mypy and pyright.
 (You don't need to worry about this if you are new to Python!)
 
@@ -153,17 +152,18 @@ This is what a command with an option called `name` looks like in the Discord cl
 
 ![Example of what name option looks like](../resources/name_option.png)
 
-Options can also have a custom description and name. If no description is provided,
-the description will default to "No Description". This example shows an option
-amed "option" with the description "your custom description". The secondoption, `option2`,
-has the name "custom-name" and description "also your custom description".
+Options can also have a custom name. The description is the required argument to the builder. This example shows an option
+named "option" with the description "your custom description". The second option, `option2`,
+keeps a different Discord name by chaining `.name("custom-name")`.
 
 ```python
+from crescent import options
+
 @client.include
 @crescent.command
 class MyCommand:
-    option = crescent.option(str, "your custom description")
-    option2 = crescent.option(str, name="custom-name", description="also your custom description")
+    option = options.string("your custom description")
+    option2 = options.string("also your custom description").name("custom-name")
 
     async def callback(self, ctx: crescent.Context) -> None:
         ...
@@ -174,21 +174,20 @@ class MyCommand:
 
 ## Option Types
 
-Crescent provides these option types. You can find more information on option types [here](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type) (You can ignore `SUBCOMMAND` and `SUBCOMMAND_GROUP` for now.)
+Crescent provides these option builders. You can find more information on option types [here](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type) (You can ignore `SUBCOMMAND` and `SUBCOMMAND_GROUP` for now.)
 This might look a bit daunting, but we will go into detail on what each option type is in this section.
 
-| Type | Option Type |
+| Builder | Option Type |
 |---|---|
-| [`str`][str] | Text |
-| [`int`][int] | Integer |
-| [`bool`][bool] | Boolean |
-| [`float`][float] | Number |
-| [`hikari.User`][hikari.users.User] | User |
-| [`hikari.Role`][hikari.guilds.Role] | Role |
-| [`crescent.Mentionable`][crescent.mentionable.Mentionable] | Role or User |
-| [`hikari.PartialChannel`][hikari.channels.PartialChannel] | Channel. The options will be the channel type and its subclasses. |
-| [`list`][list][[`hikari.PartialChannel`][hikari.channels.PartialChannel]] | Channel. ^ |
-| [`hikari.Attachment`][hikari.messages.Attachment] | Attachment |
+| `options.string(...)` | Text |
+| `options.number(...)` | Integer |
+| `options.boolean(...)` | Boolean |
+| `options.floating(...)` | Number |
+| `options.user(...)` | User |
+| `options.role(...)` | Role |
+| `options.mentionable(...)` | Role or User |
+| `options.channel(...)` | Channel. Use `.channel_types([...])` to restrict allowed kinds. |
+| `options.attachment(...)` | Attachment |
 
 ### Making Parameters Optional
 
@@ -196,10 +195,12 @@ Options will be optional if a default value is provided. This example
 shows an option with the default value `None`.
 
 ```python
+from crescent import options
+
 @client.include
 @crescent.command(name="command")
 class MyCommand:
-    optional_option = crescent.option(str, default=None)
+    optional_option = options.string("An optional value").default(None)
 
     async def callback(self, ctx: crescent.Context) -> None:
         ...
@@ -207,20 +208,22 @@ class MyCommand:
 
 ### More Information on Types
 
-Strings, Ints, Floats, and Booleans all use python's built in types.
+Strings, integers, floats, and booleans use dedicated builders on `crescent.options`.
 
 !!! note
 
-    If you are comfortable reading function overloads you can look at [the source code](https://github.com/hikari-crescent/hikari-crescent/blob/main/crescent/commands/options.py#L174).
+    If you are comfortable reading overloads you can look at [the source code](https://github.com/hikari-crescent/hikari-crescent/blob/main/crescent/commands/options.py).
 
 ```python
+from crescent import options
+
 @client.include
 @crescent.command(name="command")
 class MyCommand:
-    word = crescent.option(str)
-    integer = crescent.option(int)
-    number = crescent.option(float)
-    boolean = crescent.option(bool)
+    word = options.string("A word")
+    integer = options.number("An integer")
+    number = options.floating("A number")
+    boolean = options.boolean("A boolean")
 
     async def callback(self, ctx: crescent.Context) -> None:
         # You can now do something with the options.
@@ -233,22 +236,24 @@ These types use a hikari object.
 
 ```python
 import hikari
+from crescent import options
 
 @client.include
 @crescent.command(name="command")
 class MyCommand:
-    user = crescent.option(hikari.User)
-    role = crescent.option(hikari.Role)
-    attachment = crescent.option(hikari.Attachment)
+    user = options.user("A user")
+    role = options.role("A role")
+    attachment = options.attachment("An attachment")
 
-    # The channel type will be restricted depending on what
-    # channel object you choose. In this example only channels
-    # that users can type in can be chosen.
-    channel = crescent.option(hikari.TextableChannel)
+    # You can restrict which channel kinds Discord will allow.
+    channel = options.channel("A text channel").channel_types(
+        [hikari.ChannelType.GUILD_TEXT]
+    )
 
     # This option can only be voice channels.
-    voice_channel = crescent.option(hikari.GuildVoiceChannel)
-
+    voice_channel = options.channel("A voice channel").channel_types(
+        [hikari.ChannelType.GUILD_VOICE]
+    )
 
     async def callback(self, ctx: crescent.Context) -> None:
         ...
@@ -258,11 +263,12 @@ The final option type is mentionable, which allows a user to choose a user or ro
 
 ```python
 import hikari
+from crescent import options
 
 @client.include
 @crescent.command(name="command")
 class MyCommand:
-    mentionable = crescent.option(crescent.Mentionable)
+    mentionable = options.mentionable("A user or role")
 
     async def callback(self, ctx: crescent.Context) -> None:
         if self.mentionable.user:
@@ -276,26 +282,30 @@ class MyCommand:
 ### Autocomplete
 
 Autocomplete is a way for your command to suggest values for an option.
-The `autocomplete=` kwarg can be used for `int`, `float`, and `str` types.
+The `.autocomplete(...)` method can be used for `int`, `float`, and `str` option builders.
 
 ```python
+from crescent import options
+
 async def autocomplete_response(
     ctx: crescent.AutocompleteContext, option: hikari.AutocompleteInteractionOption
-) -> Sequence[tuple[str | int | float, str]]:
+) -> Sequence[tuple[str, str]]:
     return [("Some Option", "1234")]
 
 @client.include
 @crescent.command
 class class_example:
-    result = crescent.option(str, "Respond to the message", autocomplete=autocomplete_response)
+    result = options.string("Respond to the message").autocomplete(
+        autocomplete_response
+    )
 
     async def callback(self, ctx: crescent.Context) -> None:
         await ctx.respond(self.result, ephemeral=True)
 ```
 
 Options can also be accessed inside the callback. The `ctx.options` dictionary contains snowflakes or
-values for all the options a user has already filled out. The `ctx.fetch_values` function converts the
-snowflakes in this dictionary to the correct type and returns it. If you bot object is `hikari.impl.CacheAware`
+values for all the options a user has already filled out. The `ctx.fetch_options` function converts the
+snowflakes in this dictionary to the correct type and returns it. If your bot object is `hikari.impl.CacheAware`
 these values are fetched from the cache. Otherwise, they need to be fetched from a REST endpoint.
 
 ```python
@@ -321,13 +331,15 @@ sync or async functions. They must accept a single argument of the type that the
 return the converted value or raise an error.
 
 ```python
+from crescent import options
+
 def to_number(value: str) -> int:
     return int(value)
 
 @client.include
 @crescent.command
 class converter_example:
-    value = crescent.option(str, "Actually a number").convert(to_number)
+    value = options.string("Actually a number").convert(to_number)
 
     async def callback(self, ctx: crescent.Context) -> None:
         reveal_type(self.value)  # int

--- a/examples/basic/autocomplete.py
+++ b/examples/basic/autocomplete.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hikari
 
 import crescent
+from crescent import options
 
 bot = hikari.GatewayBot(token="...")
 client = crescent.Client(bot)
@@ -30,7 +31,7 @@ async def fetch_autocomplete_options(
 @client.include
 @crescent.command
 class class_example:
-    result = crescent.option(str, "Respond to the message", autocomplete=autocomplete_response)
+    result = options.string("Respond to the message").autocomplete(autocomplete_response)
 
     async def callback(self, ctx: crescent.Context) -> None:
         await ctx.respond(self.result, ephemeral=True)

--- a/examples/basic/basic.py
+++ b/examples/basic/basic.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
+import random
+
 import hikari
 
 import crescent
 from crescent import options
-
-import random
 
 # The bot object can be any impl that implements `hikari.traits.RESTAware` and
 # `hikari.traits.EventManagerAware`. For most users this will be `hikari.GatewayBot`.

--- a/examples/basic/basic.py
+++ b/examples/basic/basic.py
@@ -1,6 +1,7 @@
 import hikari
 
 import crescent
+from crescent import options
 
 import random
 
@@ -14,7 +15,7 @@ client = crescent.Client(bot)
 @client.include
 @crescent.command(name="random")
 class RandomNumber:
-    max = crescent.option(int)
+    max = options.number("The maximum random number to generate")
 
     async def callback(self, ctx: crescent.Context) -> None:
         await ctx.respond(random.randint(0, self.max))
@@ -23,8 +24,12 @@ class RandomNumber:
 @client.include
 @crescent.command(name="say")
 class Say:
-    to_say = crescent.option(str, "Make the bot say something", default="...", name="to-say")
-    channel = crescent.option(hikari.GuildTextChannel, "The channel to send in", default=None)
+    to_say = options.string("Make the bot say something").default("...").name("to-say")
+    channel = (
+        options.channel("The channel to send in")
+        .channel_types([hikari.ChannelType.GUILD_TEXT])
+        .default(None)
+    )
 
     async def callback(self, ctx: crescent.Context) -> None:
         if self.channel is None:

--- a/examples/error_handling/basic.py
+++ b/examples/error_handling/basic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hikari
+
 import crescent
 from crescent import options
 

--- a/examples/error_handling/basic.py
+++ b/examples/error_handling/basic.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hikari
 import crescent
+from crescent import options
 
 bot = hikari.GatewayBot(token="...")
 client = crescent.Client(bot)
@@ -42,7 +43,7 @@ async def on_autocomplete_random_error(
 @client.include
 @crescent.command(name="raise-error-cmd")
 class RaiseErrorCmd:
-    unhandled = crescent.option(bool)
+    unhandled = options.boolean("Raise an unhandled error instead")
 
     def callback(self, ctx: crescent.Context):
         if self.unhandled:
@@ -82,7 +83,7 @@ async def autocomplete(
 @client.include
 @crescent.command(name="autocomplete-error")
 class AutocompleteError:
-    option = crescent.option(str, "Type error to error out", autocomplete=autocomplete)
+    option = options.string("Type error to error out").autocomplete(autocomplete)
 
     async def callback(self, ctx: crescent.Context):
         await ctx.respond(f"{self.option} (type unhandled or error inside option)")

--- a/examples/ext/cooldowns/basic.py
+++ b/examples/ext/cooldowns/basic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 
 import hikari

--- a/examples/ext/locales/basic.py
+++ b/examples/ext/locales/basic.py
@@ -1,7 +1,7 @@
+from __future__ import annotations
+
 #  pyright: reportMissingTypeStubs=false, reportUnknownMemberType=false, reportUnknownVariableType=false
-
 # Crescent provides 2 implementations for `crescent.LocaleBuilder`
-
 import hikari
 
 import crescent

--- a/examples/ext/tasks/basic.py
+++ b/examples/ext/tasks/basic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 
 import hikari

--- a/examples/hooks/after_hooks.py
+++ b/examples/hooks/after_hooks.py
@@ -1,6 +1,7 @@
 import hikari
 
 import crescent
+from crescent import options
 
 # Hooks can be executed after commands.
 # After hooks are NOT run when there is an exception.
@@ -17,7 +18,7 @@ async def hook(ctx: crescent.Context) -> None:
 @crescent.hook(hook, after=True)
 @crescent.command(name="say")
 class Say:
-    word = crescent.option(str)
+    word = options.string("The word to say")
 
     async def callback(self, ctx: crescent.Context) -> None:
         await ctx.respond(self.word)

--- a/examples/hooks/after_hooks.py
+++ b/examples/hooks/after_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hikari
 
 import crescent

--- a/examples/hooks/group_hooks.py
+++ b/examples/hooks/group_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hikari
 
 import crescent

--- a/examples/hooks/group_hooks.py
+++ b/examples/hooks/group_hooks.py
@@ -1,6 +1,7 @@
 import hikari
 
 import crescent
+from crescent import options
 
 # Groups can also have hooks. Hooks will resolved in the order of decorators.
 # When using a `crescent.SubGroup` the group's hooks will be executed before the
@@ -43,7 +44,7 @@ sub_group = group.sub_group("my_sub_group", hooks=[second_hook], after_hooks=[se
 @crescent.hook(third_hook, after=True)
 @crescent.command(name="say")
 class Say:
-    word = crescent.option(str)
+    word = options.string("The word to say")
 
     async def callback(self, ctx: crescent.Context) -> None:
         await ctx.respond(self.word)

--- a/examples/hooks/hooks.py
+++ b/examples/hooks/hooks.py
@@ -1,6 +1,7 @@
 import hikari
 
 import crescent
+from crescent import options
 
 # Hooks allow you to execute functions before or after command
 # They execute in this order: command -> subgroup -> group -> plugin -> client
@@ -30,7 +31,7 @@ client = crescent.Client(bot)
 @crescent.hook(first_hook, second_hook(5))
 @crescent.command(name="test-command")
 class TestCommand:
-    number = crescent.option(int)
+    number = options.number("A number")
 
     async def callback(self, ctx: crescent.Context) -> None:
         # This code will never be reached due to `first_hook`
@@ -43,7 +44,7 @@ class TestCommand:
 @crescent.hook(second_hook(5))
 @crescent.command(name="test-command-two")
 class TestCommand2:
-    number = crescent.option(int)
+    number = options.number("A number")
 
     async def callback(self, ctx: crescent.Context) -> None:
         await ctx.respond("Done!")

--- a/examples/hooks/hooks.py
+++ b/examples/hooks/hooks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hikari
 
 import crescent

--- a/examples/hooks/plugin_hooks.py
+++ b/examples/hooks/plugin_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hikari
 
 import crescent

--- a/examples/hooks/plugin_hooks.py
+++ b/examples/hooks/plugin_hooks.py
@@ -1,6 +1,7 @@
 import hikari
 
 import crescent
+from crescent import options
 
 # Plugins can be added to plugins or the client. Adding hooks to the client works
 # exactly the same as plugins.
@@ -30,7 +31,7 @@ plugin = crescent.Plugin[hikari.GatewayBot, None](
 @crescent.hook(second_hook)
 @crescent.command(name="say")
 class Say:
-    word = crescent.option(str)
+    word = options.string("The word to say")
 
     async def callback(self, ctx: crescent.Context) -> None:
         await ctx.respond(self.word)

--- a/examples/locales/basic.py
+++ b/examples/locales/basic.py
@@ -42,9 +42,9 @@ class Command:
     # "en-option-name" and "en-option-description" will be used when the user is
     # using the `en-US` locale. Otherwise "option-name" and "option-description"
     # will be visible.
-    word = options.string(
-        Locale("option-description", en_US="en-option-description")
-    ).name(Locale("option-name", en_US="en-option-name"))
+    word = options.string(Locale("option-description", en_US="en-option-description")).name(
+        Locale("option-name", en_US="en-option-name")
+    )
 
     async def callback(self, ctx: crescent.Context) -> None:
         # The locale of the user who ran the command can be viewed with `Context.locale`

--- a/examples/locales/basic.py
+++ b/examples/locales/basic.py
@@ -9,6 +9,7 @@ import dataclasses
 import hikari
 
 import crescent
+from crescent import options
 
 bot = hikari.GatewayBot(token="...")
 client = crescent.Client(bot)
@@ -41,11 +42,9 @@ class Command:
     # "en-option-name" and "en-option-description" will be used when the user is
     # using the `en-US` locale. Otherwise "option-name" and "option-description"
     # will be visible.
-    word = crescent.option(
-        str,
-        name=Locale("option-name", en_US="en-option-name"),
-        description=Locale("option-description", en_US="en-option-description"),
-    )
+    word = options.string(
+        Locale("option-description", en_US="en-option-description")
+    ).name(Locale("option-name", en_US="en-option-name"))
 
     async def callback(self, ctx: crescent.Context) -> None:
         # The locale of the user who ran the command can be viewed with `Context.locale`

--- a/examples/plugins/example.py
+++ b/examples/plugins/example.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 
 import hikari

--- a/examples/plugins/folder/another_plugin.py
+++ b/examples/plugins/folder/another_plugin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hikari
 
 import crescent

--- a/examples/plugins/plugin.py
+++ b/examples/plugins/plugin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing
 
 import hikari

--- a/examples/rest/basic.py
+++ b/examples/rest/basic.py
@@ -6,6 +6,7 @@ import random
 from hikari import AutocompleteInteractionOption, RESTBot, TokenType
 
 import crescent
+from crescent import options
 
 bot = RESTBot("...", TokenType.BOT)
 client = crescent.Client(bot)
@@ -32,7 +33,7 @@ async def ping(ctx: crescent.Context) -> None:
 @client.include
 @crescent.command(name="autcomplete", description="Autocomplete Test")
 class AutocompleteTest:
-    option = crescent.option(str, "An option", autocomplete=autocomplete_callback)
+    option = options.string("An option").autocomplete(autocomplete_callback)
 
     async def callback(self, ctx: crescent.Context) -> None:
         await ctx.respond(f"You said {self.option}!")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,6 @@ dev = [
 [tool.uv.build-backend]
 module-name = ["crescent"]
 module-root = ""
-source-include = ["crescent/banner.txt"]
 
 [build-system]
 requires = ["uv_build>=0.9.9,<0.10.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,11 +71,6 @@ build-backend = "uv_build"
 [tool.mypy]
 python_version = "3.10"
 strict = true
-warn_unused_configs = true
-warn_return_any = true
-warn_redundant_casts = true
-namespace_packages = true
-warn_unused_ignores = false
 
 [tool.pyright]
 include = ["crescent", "examples"]
@@ -83,30 +78,13 @@ exclude = ["tests"]
 pythonVersion = "3.10"
 typeCheckingMode = "strict"
 reportPrivateUsage = false
-reportImportCycles = false
 reportIncompatibleMethodOverride = false
-reportWildcardImportFromLibrary = false
 
 [tool.ruff]
-target-version = "py310"
-lint.ignore = [
-  # Allow * imports to be used in the module level
-  "F403",
-  "F405",
-]
-lint.select = [
-  # Pyflakes
-  "E",
-  "F",
-  # Dangling Tasks
-  "RUF006",
-]
+lint.select = ["E", "W", "F", "RUF", "I", "PT"]
 line-length = 99
 
 [tool.ruff.lint.pyflakes]
 extend-generics = [
     "crescent.Plugin"
 ]
-
-[tool.pytest.ini_options]
-asyncio_mode = 'strict'

--- a/tests/crescent/commands/test_build.py
+++ b/tests/crescent/commands/test_build.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from hikari import CommandType, Permissions
 from hikari.impl.entity_factory import EntityFactoryImpl
 

--- a/tests/crescent/commands/test_command_function.py
+++ b/tests/crescent/commands/test_command_function.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from types import FunctionType
 
 from hikari import UNDEFINED, CommandType, Message, User

--- a/tests/crescent/commands/test_defaults.py
+++ b/tests/crescent/commands/test_defaults.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from hikari import UNDEFINED, Message, Permissions, User
 
 from crescent import Context, command, message_command, user_command

--- a/tests/crescent/commands/test_option_types.py
+++ b/tests/crescent/commands/test_option_types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from hikari import ChannelType, OptionType
 
 from crescent import command, options

--- a/tests/crescent/commands/test_option_types.py
+++ b/tests/crescent/commands/test_option_types.py
@@ -1,43 +1,53 @@
-from hikari import (
-    Attachment,
-    GuildTextChannel,
-    GuildVoiceChannel,
-    OptionType,
-    PartialChannel,
-    Role,
-    User,
-)
+from hikari import ChannelType, OptionType
 
-from crescent import Mentionable, command, option
+from crescent import command, options
 
 
 def test_option_types():
     @command(name="all-option-types")
     class AllOptionTypes:
-        text = option(str)
-        integer = option(int)
-        boolean = option(bool)
-        number = option(float)
-        user = option(User)
-        role = option(Role)
-        mentionable = option(Mentionable)
-        channel = option(PartialChannel)
-        channel_list = option([GuildTextChannel, GuildVoiceChannel])
-        attachment = option(Attachment)
+        text = options.string("text")
+        integer = options.number("integer")
+        boolean = options.boolean("boolean")
+        number = options.floating("number")
+        user = options.user("user")
+        role = options.role("role")
+        mentionable = options.mentionable("mentionable")
+        channel = options.channel("channel")
+        channel_list = options.channel("channel list").channel_types(
+            [ChannelType.GUILD_TEXT, ChannelType.GUILD_VOICE]
+        )
+        attachment = options.attachment("attachment")
 
         async def callback(self, ctx): ...
 
-    options = AllOptionTypes.metadata.app_command.options
+    command_options = AllOptionTypes.metadata.app_command.options
 
-    assert options
+    assert command_options
 
-    assert options[0].type == OptionType.STRING
-    assert options[1].type == OptionType.INTEGER
-    assert options[2].type == OptionType.BOOLEAN
-    assert options[3].type == OptionType.FLOAT
-    assert options[4].type == OptionType.USER
-    assert options[5].type == OptionType.ROLE
-    assert options[6].type == OptionType.MENTIONABLE
-    assert options[7].type == OptionType.CHANNEL
-    assert options[8].type == OptionType.CHANNEL
-    assert options[9].type == OptionType.ATTACHMENT
+    assert command_options[0].type == OptionType.STRING
+    assert command_options[1].type == OptionType.INTEGER
+    assert command_options[2].type == OptionType.BOOLEAN
+    assert command_options[3].type == OptionType.FLOAT
+    assert command_options[4].type == OptionType.USER
+    assert command_options[5].type == OptionType.ROLE
+    assert command_options[6].type == OptionType.MENTIONABLE
+    assert command_options[7].type == OptionType.CHANNEL
+    assert command_options[8].type == OptionType.CHANNEL
+    assert command_options[9].type == OptionType.ATTACHMENT
+
+
+def test_string_length_limits():
+    @command(name="string-length-limits")
+    class StringLengthLimits:
+        value = options.string("value").min_length(2).max_length(4)
+
+        async def callback(self, ctx): ...
+
+    command_options = StringLengthLimits.metadata.app_command.options
+
+    assert command_options
+    assert command_options[0].min_length == 2
+    assert command_options[0].max_length == 4
+    assert command_options[0].min_value is None
+    assert command_options[0].max_value is None

--- a/tests/crescent/commands/test_permissions.py
+++ b/tests/crescent/commands/test_permissions.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
+import pytest
 from hikari import PermissionOverwrite
-from pytest import raises
 
 from crescent import Context, Group, PermissionsError, command
 
@@ -7,7 +9,7 @@ from crescent import Context, Group, PermissionsError, command
 def test_no_perms_in_subcommand_group():
     group = Group("abcd")
 
-    with raises(PermissionsError):
+    with pytest.raises(PermissionsError):
 
         @group.child
         @command(default_member_permissions=PermissionOverwrite(id=0, type=0))
@@ -22,7 +24,7 @@ def test_no_perms_in_subcommand_subgroup():
     group = Group("abcd")
     sub_group = group.sub_group("abcd")
 
-    with raises(PermissionsError):
+    with pytest.raises(PermissionsError):
 
         @sub_group.child
         @command(default_member_permissions=PermissionOverwrite(id=0, type=0))

--- a/tests/crescent/ctx/test_autocomplete_ctx.py
+++ b/tests/crescent/ctx/test_autocomplete_ctx.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 from copy import copy
 from unittest.mock import AsyncMock, Mock
 
+import pytest
 from hikari import CommandInteractionOption, InteractionType, OptionType
 from hikari.impl import CacheImpl, RESTClientImpl
-from pytest import mark
 
 from crescent import AutocompleteContext
 from crescent.mentionable import Mentionable
@@ -64,7 +66,7 @@ guild_ctx.interaction.guild_id = 1234
 guild_ctx.interaction.options = options_with_role
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_fetch_options_not_cached():
     fetch_member_mock = AsyncMock(return_value="member")
     fetch_user_mock = AsyncMock(return_value="user")
@@ -103,7 +105,7 @@ async def test_fetch_options_not_cached():
     }
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_fetch_options_guild_not_cached():
     fetch_member_mock = AsyncMock(return_value="member")
     fetch_user_mock = AsyncMock(return_value="user")
@@ -153,7 +155,7 @@ async def test_fetch_options_guild_not_cached():
     }
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_fetch_options_cached():
     get_member_mock = Mock(return_value="member")
     get_user_mock = Mock(return_value="user")
@@ -178,7 +180,7 @@ async def test_fetch_options_cached():
     }
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_fetch_options_guild_cached():
     role_mock = Mock()
     role_mock.id = 12345

--- a/tests/crescent/ctx/test_ctx.py
+++ b/tests/crescent/ctx/test_ctx.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from crescent.context import InteractionContext
 
 

--- a/tests/crescent/hooks/test_hook_order.py
+++ b/tests/crescent/hooks/test_hook_order.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from types import MethodType
 from typing import TYPE_CHECKING, Any
 
-from crescent import Group, Plugin, command, hook, event
 from hikari import Event
+
+from crescent import Group, Plugin, command, event, hook
 from tests.utils import MockClient
 
 

--- a/tests/crescent/internal/test_autocomplete_resp.py
+++ b/tests/crescent/internal/test_autocomplete_resp.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
+import pytest
 from hikari import AutocompleteInteractionOption, OptionType
-from pytest import mark
 
 from crescent.internal.handle_resp import _get_option_recursive
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 class TestAutocompleteResp:
     async def test_top_level_command(self):
         options = [

--- a/tests/crescent/internal/test_compare_commands.py
+++ b/tests/crescent/internal/test_compare_commands.py
@@ -1,6 +1,6 @@
-from unittest.mock import Mock
+from __future__ import annotations
 
-from crescent.internal.app_command import AppCommand
+from unittest.mock import Mock
 
 from hikari import (
     ApplicationIntegrationType,
@@ -9,6 +9,7 @@ from hikari import (
     SlashCommand,
 )
 
+from crescent.internal.app_command import AppCommand
 
 DEFAULT_CONTEXT = ()
 DEFAULT_INT = (ApplicationIntegrationType.GUILD_INSTALL,)

--- a/tests/crescent/internal/test_handle_resp.py
+++ b/tests/crescent/internal/test_handle_resp.py
@@ -20,7 +20,6 @@ from pytest import mark
 
 from crescent import Context, catch_autocomplete, catch_command, command, hook
 import crescent
-from crescent.commands.options import option
 from crescent.exceptions import ConverterExceptions
 from crescent.internal.handle_resp import handle_resp
 from tests.utils import MockClient, MockRESTClient
@@ -121,7 +120,7 @@ async def test_converter_ok() -> None:
     @client.include
     @command
     class test_command:
-        arg = option(str).convert(int)
+        arg = crescent.options.string("arg").convert(int)
 
         async def callback(self, ctx: Context) -> None:
             nonlocal arg_val
@@ -146,7 +145,7 @@ async def test_converter_error() -> None:
         exc = _exc
 
     class test_command:
-        arg = option(str).convert(int)
+        arg = crescent.options.string("arg").convert(int)
 
         async def callback(self, ctx: Context) -> None:
             nonlocal arg_val
@@ -316,9 +315,9 @@ async def test_handle_autocomplete_error():
     @client.include
     @command(name="test_command")
     class TestCommand:
-        option = crescent.option(str, autocomplete=autocomplete_resp)
+        option = crescent.options.string("option").autocomplete(autocomplete_resp)
 
-        def callback(ctx: Context):
+        def callback(self, ctx: Context):
             nonlocal command_was_run
             command_was_run = True
 
@@ -358,9 +357,9 @@ async def test_unhandled_autocomplete_error():
     @client.include
     @command(name="test_command")
     class TestCommand:
-        option = crescent.option(str, autocomplete=autocomplete_resp)
+        option = crescent.options.string("option").autocomplete(autocomplete_resp)
 
-        def callback(ctx: Context):
+        def callback(self, ctx: Context):
             nonlocal command_was_run
             command_was_run = True
 

--- a/tests/crescent/internal/test_handle_resp.py
+++ b/tests/crescent/internal/test_handle_resp.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 from asyncio import get_event_loop
 from typing import List, cast
 from unittest.mock import AsyncMock, Mock
 
+import pytest
 from hikari import (
     ApplicationContextType,
     AutocompleteInteraction,
@@ -16,10 +19,9 @@ from hikari import (
     OptionType,
 )
 from hikari.impl import RESTClientImpl
-from pytest import mark
 
-from crescent import Context, catch_autocomplete, catch_command, command, hook
 import crescent
+from crescent import Context, catch_autocomplete, catch_command, command, hook
 from crescent.exceptions import ConverterExceptions
 from crescent.internal.handle_resp import handle_resp
 from tests.utils import MockClient, MockRESTClient
@@ -111,7 +113,7 @@ def MockAutocompleteEvent(name, option_name, client):
     )
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_converter_ok() -> None:
     client = MockClient()
 
@@ -131,7 +133,7 @@ async def test_converter_ok() -> None:
     assert arg_val == 1
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_converter_error() -> None:
     client = MockClient()
 
@@ -167,7 +169,7 @@ async def test_converter_error() -> None:
     assert meta.command is test_command
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_handle_resp_slash_function():
     client = MockClient()
 
@@ -184,7 +186,7 @@ async def test_handle_resp_slash_function():
     assert command_was_run
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_handle_resp_slash_class():
     client = MockClient()
 
@@ -202,7 +204,7 @@ async def test_handle_resp_slash_class():
     assert command_was_run
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_hooks():
     client = MockClient()
     command_was_run = False
@@ -238,7 +240,7 @@ async def test_hooks():
     assert command_was_run
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_handle_command_error():
     client = MockClient()
     command_was_run = False
@@ -264,7 +266,7 @@ async def test_handle_command_error():
     assert command_was_run
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_unhandled_command_error():
     client = MockClient()
     command_was_run = False
@@ -289,7 +291,7 @@ async def test_unhandled_command_error():
     assert command_was_run
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_handle_autocomplete_error():
     client = MockClient()
     command_was_run = False
@@ -332,7 +334,7 @@ async def test_handle_autocomplete_error():
     assert not command_was_run
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_unhandled_autocomplete_error():
     client = MockClient()
     command_was_run = False
@@ -374,7 +376,7 @@ async def test_unhandled_autocomplete_error():
     assert not command_was_run
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_rest_bot_command():
     client = MockRESTClient()
 
@@ -403,7 +405,7 @@ async def test_rest_bot_command():
     assert command_was_run
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_rest_future_is_set():
     client = MockRESTClient()
 

--- a/tests/crescent/internal/test_registry.py
+++ b/tests/crescent/internal/test_registry.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 from collections import defaultdict
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from hikari import Message, User
 from hikari.impl import CacheImpl, RESTClientImpl
-from pytest import fixture, mark
 
 from crescent import Context, command
 from crescent import message_command as _message_command
@@ -14,7 +16,7 @@ GUILD_ID = 123456789
 
 
 class TestRegistry:
-    @fixture(autouse=True)
+    @pytest.fixture(autouse=True)
     def mock_send(self):
         self.posted_commands = defaultdict(list)
 
@@ -28,7 +30,7 @@ class TestRegistry:
 
         CacheImpl.get_guilds_view = MagicMock(return_value={0: GUILD_ID})
 
-    @mark.asyncio
+    @pytest.mark.asyncio
     async def test_post_commands(self):
         client = MockClient(default_guild=GUILD_ID)
 

--- a/tests/crescent/plugins/hook_plugin.py
+++ b/tests/crescent/plugins/hook_plugin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import crescent
 
 

--- a/tests/crescent/plugins/plugin.py
+++ b/tests/crescent/plugins/plugin.py
@@ -1,5 +1,6 @@
-# This plugin is loaded by the `test_plugins.py` tests
+from __future__ import annotations
 
+# This plugin is loaded by the `test_plugins.py` tests
 from hikari import MessageCreateEvent
 
 from crescent import Context, Plugin, catch_command, command, event

--- a/tests/crescent/plugins/plugin_folder/__init__.py
+++ b/tests/crescent/plugins/plugin_folder/__init__.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 # NOTE: This file is not required. It is here to test that files starting with _ are
 # skipped properly.

--- a/tests/crescent/plugins/plugin_folder/plugin.py
+++ b/tests/crescent/plugins/plugin_folder/plugin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from crescent import Plugin
 
 plugin = Plugin()

--- a/tests/crescent/plugins/plugin_folder/plugin_subfolder/plugin.py
+++ b/tests/crescent/plugins/plugin_folder/plugin_subfolder/plugin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from crescent import Plugin
 
 plugin = Plugin()

--- a/tests/crescent/plugins/plugin_folder_not_strict/plugin.py
+++ b/tests/crescent/plugins/plugin_folder_not_strict/plugin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from crescent import Plugin
 
 plugin = Plugin()

--- a/tests/crescent/plugins/test_plugins.py
+++ b/tests/crescent/plugins/test_plugins.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import pytest
 from hikari import MessageCreateEvent
-from pytest import LogCaptureFixture, raises
 
 from crescent.exceptions import PluginAlreadyLoadedError
 from tests.crescent.plugins.plugin import (
@@ -34,7 +34,7 @@ class TestPlugins:
     def test_load_not_plugin(self):
         client = MockClient()
 
-        with raises(ValueError):
+        with pytest.raises(ValueError, match=r"has no `plugin`"):
             client.plugins.load("tests.crescent.plugins.not_plugin")
 
         plugin = client.plugins.load("tests.crescent.plugins.not_plugin", strict=False)
@@ -92,7 +92,7 @@ class TestPlugins:
         assert orig is orig2
         assert orig is not new
 
-    def test_load_folder(self, caplog: LogCaptureFixture):
+    def test_load_folder(self, caplog: pytest.LogCaptureFixture):
         client = MockClient()
 
         plugins = client.plugins.load_folder("tests.crescent.plugins.plugin_folder")
@@ -115,7 +115,7 @@ class TestPlugins:
 
         client.plugins.load_folder("tests.crescent.plugins.plugin_folder")
 
-        with raises(PluginAlreadyLoadedError):
+        with pytest.raises(PluginAlreadyLoadedError):
             client.plugins.load_folder("tests.crescent.plugins.plugin_folder", refresh=False)
 
         client.plugins.load_folder("tests.crescent.plugins.plugin_folder", refresh=True)
@@ -123,7 +123,7 @@ class TestPlugins:
     def test_load_folder_with_not_plugins(self):
         client = MockClient()
 
-        with raises(ValueError):
+        with pytest.raises(ValueError, match=r"has no `plugin`"):
             client.plugins.load_folder("tests.crescent.plugins.plugin_folder_not_strict")
 
         # Plugins should be empty after loading fails
@@ -137,7 +137,7 @@ class TestPlugins:
 
         assert arrays_contain_same_elements([plugin], plugins)
 
-    def test_load_dir_not_exists(self, caplog: LogCaptureFixture):
+    def test_load_dir_not_exists(self, caplog: pytest.LogCaptureFixture):
         client = MockClient()
 
         client.plugins.load_folder("does.not.exist")
@@ -171,7 +171,7 @@ class TestPlugins:
 
         client.plugins.load("tests.crescent.plugins.plugin")
 
-        with raises(PluginAlreadyLoadedError):
+        with pytest.raises(PluginAlreadyLoadedError):
             client.plugins.load("tests.crescent.plugins.plugin")
 
     def test_client_loaded(self):
@@ -187,7 +187,7 @@ class TestPlugins:
         plugin = client.plugins.load("tests.crescent.plugins.plugin")
         client.plugins.unload("tests.crescent.plugins.plugin")
 
-        with raises(AttributeError):
+        with pytest.raises(AttributeError):
             plugin.app
 
     def test_model(self):

--- a/tests/crescent/test_error_handling.py
+++ b/tests/crescent/test_error_handling.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hikari
 
 import crescent

--- a/tests/crescent/test_locale.py
+++ b/tests/crescent/test_locale.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from crescent.locale import str_or_build_locale
 from tests.utils import Locale
 

--- a/tests/crescent/utils/test_any_issubclass.py
+++ b/tests/crescent/utils/test_any_issubclass.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from crescent.utils import any_issubclass
 
 

--- a/tests/test_bot/test_bot.py
+++ b/tests/test_bot/test_bot.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import os
 from datetime import datetime

--- a/tests/test_bot/test_bot.py
+++ b/tests/test_bot/test_bot.py
@@ -7,6 +7,7 @@ import dotenv
 import hikari
 
 import crescent
+from crescent import options
 from crescent.exceptions import ConverterExceptions
 from crescent.ext import tasks
 
@@ -79,6 +80,7 @@ class DMCommand:
     async def callback(self, ctx: crescent.Context) -> None:
         await ctx.respond("hi!")
 
+
 @client.include
 @crescent.command(name="guild-only", context_types=(hikari.ApplicationContextType.GUILD,))
 class GuildCommand:
@@ -99,9 +101,9 @@ async def handle_converter_err(e: ConverterExceptions, ctx: crescent.Context) ->
 @client.include
 @crescent.command(name="converters", description="converters!")
 class ConverterCommand:
-    username = crescent.option(str, "username").convert(normalize_name)
-    url1 = crescent.option(str, "url1").convert(fancy_validate_url)
-    url2 = crescent.option(str, "url2").convert(fancy_validate_url)
+    username = options.string("username").convert(normalize_name)
+    url1 = options.string("url1").convert(fancy_validate_url)
+    url2 = options.string("url2").convert(fancy_validate_url)
 
     async def callback(self, ctx: crescent.Context) -> None:
         await ctx.respond(str((self.username, self.url1, self.url2)))
@@ -110,9 +112,9 @@ class ConverterCommand:
 @client.include
 @crescent.command(name="class-command", description="testing testing 123")
 class ClassCommand:
-    arg = crescent.option(str, "description")
-    another_arg = crescent.option(str, name="another-arg")
-    converted = crescent.option(str, name="str-to-num").convert(lambda v: int(v))
+    arg = options.string("description")
+    another_arg = options.string("another arg").name("another-arg")
+    converted = options.string("number as text").name("str-to-num").convert(lambda v: int(v))
 
     async def callback(self, ctx: crescent.Context) -> None:
         await ctx.respond(

--- a/tests/test_bot/test_plugin.py
+++ b/tests/test_bot/test_plugin.py
@@ -1,3 +1,4 @@
+from hikari import GatewayBot
 import crescent
 
 
@@ -9,7 +10,7 @@ async def command_hook(ctx: crescent.Context) -> None:
     await ctx.respond("Command hook called.")
 
 
-plugin = crescent.Plugin(command_hooks=[plugin_hook])
+plugin: crescent.Plugin[GatewayBot, None] = crescent.Plugin(command_hooks=[plugin_hook])
 
 
 @plugin.include

--- a/tests/test_bot/test_plugin.py
+++ b/tests/test_bot/test_plugin.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from hikari import GatewayBot
+
 import crescent
 
 

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,13 +1,13 @@
-from typing import Sequence
+from __future__ import annotations
 
 from tests.utils.arrays import arrays_contain_same_elements
 from tests.utils.locale import Locale
 from tests.utils.mock_client import MockBot, MockClient, MockRESTClient
 
-__all__: Sequence[str] = (
+__all__ = (
+    "Locale",
     "MockBot",
     "MockClient",
     "MockRESTClient",
     "arrays_contain_same_elements",
-    "Locale",
 )

--- a/tests/utils/arrays.py
+++ b/tests/utils/arrays.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import Any, Sequence
+from typing import Any
 
-__all__: Sequence[str] = ("arrays_contain_same_elements",)
+__all__ = ("arrays_contain_same_elements",)
 
 
 def arrays_contain_same_elements(arr1: list[Any], arr2: list[Any]) -> bool:

--- a/tests/utils/locale.py
+++ b/tests/utils/locale.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Sequence
 
 from crescent import LocaleBuilder
 
-__all__: Sequence[str] = ("Locale",)
+__all__ = ("Locale",)
 
 
 @dataclass

--- a/tests/utils/mock_client.py
+++ b/tests/utils/mock_client.py
@@ -1,7 +1,10 @@
-from hikari import GatewayBot, Snowflake, StartedEvent, RESTBot
+from __future__ import annotations
+
+from typing import Any
+
+from hikari import GatewayBot, RESTBot, Snowflake, StartedEvent
 
 from crescent import Client
-from typing import Any
 from crescent.internal.registry import CommandHandler
 
 


### PR DESCRIPTION
closes #386

BREAKING CHANGE: multiple:
These arguments were previously available as positional, but are now keyword-only:
- `Context.defer(ephemeral=...)`
- `Context.respond_with_builder(ensure_message=...)`
- `@cronjob(on_startup=...)`
- `EventMeta.add_hooks(prepend=...)`
- `PluginManager.load(_folder)(refresh=..., strict=...)`

TODO: document new option system