### PR TITLE
refactor!: add a bunch of linting rules and fix issues

### DIFF
--- a/crescent/__init__.py
+++ b/crescent/__init__.py
@@ -1,52 +1,67 @@
-from importlib.metadata import version
-from typing import Sequence
+from __future__ import annotations
 
-from crescent.client import *
-from crescent.commands import *
-from crescent.context import *
-from crescent.errors import *
-from crescent.events import *
-from crescent.exceptions import *
-from crescent.hooks import *
-from crescent.locale import *
-from crescent.mentionable import *
-from crescent.plugin import *
-from crescent.typedefs import *
+from importlib.metadata import version
+
+from crescent.client import Client, GatewayTraits, RESTTraits
+from crescent.commands import Group, SubGroup, command, message_command, options, user_command
+from crescent.context import AutocompleteContext, Context
+from crescent.errors import catch_autocomplete, catch_command, catch_event
+from crescent.events import event
+from crescent.exceptions import (
+    AlreadyRegisteredError,
+    ConverterExceptionMeta,
+    ConverterExceptions,
+    CrescentException,
+    PermissionsError,
+    PluginAlreadyLoadedError,
+)
+from crescent.hooks import HookResult, hook
+from crescent.locale import LocaleBuilder
+from crescent.mentionable import Mentionable
+from crescent.plugin import Plugin, PluginManager
+from crescent.typedefs import (
+    AutocompleteCallbackT,
+    ClassCommandProto,
+    CommandCallbackT,
+    CommandHookCallbackT,
+    CommandOptionsT,
+    OptionTypesT,
+)
 
 __version__: str = version("hikari-crescent")
 
-__all__: Sequence[str] = (
-    "command",
-    "user_command",
-    "message_command",
-    "options",
-    "hook",
-    "HookResult",
-    "Group",
-    "SubGroup",
-    "Client",
-    "GatewayTraits",
-    "RESTTraits",
-    "Context",
-    "AutocompleteContext",
-    "catch_command",
-    "catch_event",
-    "catch_autocomplete",
-    "event",
-    "CrescentException",
-    "ConverterExceptions",
-    "ConverterExceptionMeta",
+__all__ = (
     "AlreadyRegisteredError",
-    "PluginAlreadyLoadedError",
-    "PermissionsError",
+    "AutocompleteCallbackT",
+    "AutocompleteContext",
+    "ClassCommandProto",
+    "Client",
+    "CommandCallbackT",
+    "CommandHookCallbackT",
+    "CommandOptionsT",
+    "Context",
+    "ConverterExceptionMeta",
+    "ConverterExceptions",
+    "CrescentException",
+    "GatewayTraits",
+    "Group",
+    "HookResult",
     "LocaleBuilder",
     "Mentionable",
-    "CommandCallbackT",
-    "CommandOptionsT",
     "OptionTypesT",
-    "CommandHookCallbackT",
-    "AutocompleteCallbackT",
-    "ClassCommandProto",
+    "PermissionsError",
     "Plugin",
+    "PluginAlreadyLoadedError",
     "PluginManager",
+    "RESTTraits",
+    "SubGroup",
+    "catch_autocomplete",
+    "catch_command",
+    "catch_event",
+    "command",
+    "event",
+    "hook",
+    "message_command",
+    "options",
+    "user_command",
 )

--- a/crescent/_about.py
+++ b/crescent/_about.py
@@ -1,6 +1,6 @@
-from typing import Sequence
+from __future__ import annotations
 
-__all__: Sequence[str] = ("__maintainer__", "__copyright__", "__license__")
+__all__ = ("__copyright__", "__license__", "__maintainer__")
 
 __maintainer__ = "Lunarmagpie"
 __copyright__ = "© 2021-present Lunarmagpie"

--- a/crescent/client.py
+++ b/crescent/client.py
@@ -192,7 +192,8 @@ class Client:
         )
 
     async def _on_rest_interaction(
-        self, interaction: PartialInteraction
+        self,
+        interaction: PartialInteraction,
     ) -> InteractionResponseBuilder:
         future: Future[InteractionResponseBuilder] = get_running_loop().create_future()
         create_task(handle_resp(self, interaction, future))
@@ -211,7 +212,8 @@ class Client:
     def include(self, obj: None = ...) -> Callable[[INCLUDABLE], INCLUDABLE]: ...
 
     def include(
-        self, obj: INCLUDABLE | None = None
+        self,
+        obj: INCLUDABLE | None = None,
     ) -> INCLUDABLE | Callable[[INCLUDABLE], INCLUDABLE]:
         """
         Register an includable object, such as an event or command handler.
@@ -260,7 +262,10 @@ class Client:
         return self._command_handler
 
     async def on_crescent_command_error(
-        self, exc: Exception, ctx: Context, was_handled: bool
+        self,
+        exc: Exception,
+        ctx: Context,
+        was_handled: bool,
     ) -> None:
         """
         This function is run when there is an error in a crescent command
@@ -278,7 +283,10 @@ class Client:
         )
 
     async def on_crescent_event_error(
-        self, exc: Exception, event: hk_Event, was_handled: bool
+        self,
+        exc: Exception,
+        event: hk_Event,
+        was_handled: bool,
     ) -> None:
         """
         This function is run when there is an error in a crescent event
@@ -324,7 +332,8 @@ class Client:
         self._started = True
 
     def _add_startup_callback(
-        self, callback: Callable[[], Awaitable[None]]
+        self,
+        callback: Callable[[], Awaitable[None]],
     ) -> Callable[[], None] | None:
         async def on_start(_: Any) -> None:
             await callback()

--- a/crescent/client.py
+++ b/crescent/client.py
@@ -280,7 +280,7 @@ class Client:
         logger.error(
             "Unhandled exception occurred in the command %s",
             ctx.command,
-            exc_info=(exc.__class__, exc, exc.__traceback__),
+            exc_info=exc,
         )
 
     async def on_crescent_event_error(
@@ -300,7 +300,7 @@ class Client:
         logger.error(
             "Unhandled exception occurred for %s",
             type(event),
-            exc_info=(exc.__class__, exc, exc.__traceback__),
+            exc_info=exc,
         )
 
     async def on_crescent_autocomplete_error(
@@ -322,7 +322,7 @@ class Client:
             "Unhandled exception occurred in the autocomplete interaction for %s (option: %s)",
             ctx.command,
             option.name,
-            exc_info=(exc.__class__, exc, exc.__traceback__),
+            exc_info=exc,
         )
 
     def _run_future(self, callback: Coroutine[Any, Any, Any]) -> None:

--- a/crescent/client.py
+++ b/crescent/client.py
@@ -265,7 +265,8 @@ class Client:
         self,
         exc: Exception,
         ctx: Context,
-        was_handled: bool,
+        was_handled: bool,  # noqa: FBT001
+        /,
     ) -> None:
         """
         This function is run when there is an error in a crescent command
@@ -286,7 +287,8 @@ class Client:
         self,
         exc: Exception,
         event: hk_Event,
-        was_handled: bool,
+        was_handled: bool,  # noqa: FBT001
+        /,
     ) -> None:
         """
         This function is run when there is an error in a crescent event
@@ -306,7 +308,8 @@ class Client:
         exc: Exception,
         ctx: AutocompleteContext,
         option: AutocompleteInteractionOption,
-        was_handled: bool,
+        was_handled: bool,  # noqa: FBT001
+        /,
     ) -> None:
         """
         This function is run when there is an error in an autocomplete handler

--- a/crescent/client.py
+++ b/crescent/client.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
-from asyncio import get_running_loop
+import logging
+from asyncio import Future, get_running_loop
 from contextlib import suppress
 from functools import partial
 from itertools import chain
-from traceback import print_exception
-from typing import TYPE_CHECKING, Protocol, overload, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar, overload, runtime_checkable
 
-from hikari import AutocompleteInteraction, AutocompleteInteractionOption, CommandInteraction
-from hikari import Event as hk_Event
 from hikari import (
+    AutocompleteInteraction,
+    AutocompleteInteractionOption,
+    CommandInteraction,
     InteractionCreateEvent,
     InteractionServerAware,
     PartialInteraction,
@@ -17,34 +18,37 @@ from hikari import (
     Snowflakeish,
     StartedEvent,
 )
+from hikari import Event as hk_Event
 from hikari.traits import EventManagerAware, RESTAware
 
 from crescent.hooks import add_hooks
 from crescent.internal.handle_resp import handle_resp
-from crescent.internal.includable import Includable
 from crescent.internal.registry import CommandHandler, ErrorHandler
 from crescent.plugin import PluginManager
-from crescent.typedefs import EventHookCallbackT
 from crescent.utils import create_task
 
 if TYPE_CHECKING:
-    from asyncio import Future
-    from typing import Any, Awaitable, Callable, Coroutine, Sequence, TypeVar
+    from collections.abc import Awaitable, Callable, Coroutine, Sequence
 
     from hikari.api import InteractionResponseBuilder
 
     from crescent.context import AutocompleteContext, Context
+    from crescent.internal.includable import Includable
     from crescent.typedefs import (
         AutocompleteErrorHandlerCallbackT,
         CommandErrorHandlerCallbackT,
         CommandHookCallbackT,
         EventErrorHandlerCallbackT,
+        EventHookCallbackT,
     )
 
     INCLUDABLE = TypeVar("INCLUDABLE", bound=Includable[Any])
 
 
-__all__: Sequence[str] = ("Client", "GatewayTraits", "RESTTraits")
+__all__ = ("Client", "GatewayTraits", "RESTTraits")
+
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 @runtime_checkable
@@ -94,7 +98,7 @@ class Client:
         command_after_hooks: list[CommandHookCallbackT] | None = None,
         event_hooks: list[EventHookCallbackT[hk_Event]] | None = None,
         event_after_hooks: list[EventHookCallbackT[hk_Event]] | None = None,
-    ):
+    ) -> None:
         """
         Args:
             app:
@@ -179,12 +183,12 @@ class Client:
             app.event_manager.subscribe(InteractionCreateEvent, self._on_interaction_event)
             return
         app.interaction_server.set_listener(
-            CommandInteraction,  # pyright: ignore
-            self._on_rest_interaction,  # type: ignore
+            CommandInteraction,
+            self._on_rest_interaction,  # type: ignore[arg-type]
         )
         app.interaction_server.set_listener(
-            AutocompleteInteraction,  # type: ignore
-            self._on_rest_interaction,  # type: ignore
+            AutocompleteInteraction,  # type: ignore[arg-type]
+            self._on_rest_interaction,  # type: ignore[arg-type]
         )
 
     async def _on_rest_interaction(
@@ -267,8 +271,11 @@ class Client:
             return
         with suppress(Exception):
             await ctx.respond("An unexpected error occurred.", ephemeral=True)
-        print(f"Unhandled exception occurred in the command {ctx.command}:")
-        print_exception(exc.__class__, exc, exc.__traceback__)
+        logger.error(
+            "Unhandled exception occurred in the command %s",
+            ctx.command,
+            exc_info=(exc.__class__, exc, exc.__traceback__),
+        )
 
     async def on_crescent_event_error(
         self, exc: Exception, event: hk_Event, was_handled: bool
@@ -280,8 +287,11 @@ class Client:
         """
         if was_handled:
             return
-        print(f"Unhandled exception occurred for {type(event)}:")
-        print_exception(exc.__class__, exc, exc.__traceback__)
+        logger.error(
+            "Unhandled exception occurred for %s",
+            type(event),
+            exc_info=(exc.__class__, exc, exc.__traceback__),
+        )
 
     async def on_crescent_autocomplete_error(
         self,
@@ -297,11 +307,12 @@ class Client:
         """
         if was_handled:
             return
-        print(
-            f"Unhandled exception occurred in the autocomplete interaction for {ctx.command}"
-            f" (option: {option.name}):"
+        logger.error(
+            "Unhandled exception occurred in the autocomplete interaction for %s (option: %s)",
+            ctx.command,
+            option.name,
+            exc_info=(exc.__class__, exc, exc.__traceback__),
         )
-        print_exception(exc.__class__, exc, exc.__traceback__)
 
     def _run_future(self, callback: Coroutine[Any, Any, Any]) -> None:
         if self._started:
@@ -321,7 +332,7 @@ class Client:
         if isinstance(self.app, GatewayTraits):
             self.app.event_manager.subscribe(StartedEvent, on_start)
             return partial(self.app.event_manager.unsubscribe, StartedEvent, on_start)
-        elif isinstance(self.app, RESTBotAware):
+        if isinstance(self.app, RESTBotAware):
             self.app.add_startup_callback(on_start)
             return partial(self.app.remove_startup_callback, on_start)
         return None

--- a/crescent/commands/__init__.py
+++ b/crescent/commands/__init__.py
@@ -1,16 +1,16 @@
-from typing import Sequence
+from __future__ import annotations
 
-from crescent.commands.decorators import *
 from crescent.commands import options
+from crescent.commands.decorators import command, message_command, user_command
+from crescent.commands.groups import Group, SubGroup
 from crescent.commands.options import ClassCommandOption
-from crescent.commands.groups import *
 
-__all__: Sequence[str] = (
-    "command",
-    "user_command",
-    "message_command",
+__all__ = (
+    "ClassCommandOption",
     "Group",
     "SubGroup",
-    "ClassCommandOption",
+    "command",
+    "message_command",
     "options",
+    "user_command",
 )

--- a/crescent/commands/decorators.py
+++ b/crescent/commands/decorators.py
@@ -98,7 +98,8 @@ def _class_command_callback(
 
 @overload
 def command(
-    callback: CommandCallbackT | type[ClassCommandProto], /
+    callback: CommandCallbackT | type[ClassCommandProto],
+    /,
 ) -> Includable[AppCommandMeta]: ...
 
 

--- a/crescent/commands/decorators.py
+++ b/crescent/commands/decorators.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from asyncio import Task, create_task
 from functools import partial, wraps
 from inspect import isawaitable, isclass, isfunction
-from typing import TYPE_CHECKING, Awaitable, Callable, Iterable, cast, overload
+from typing import TYPE_CHECKING, cast, overload
 
 from hikari import (
     UNDEFINED,
@@ -19,13 +19,14 @@ from hikari import (
 from crescent.commands.options import ClassCommandOption, Marker
 from crescent.exceptions import ConverterExceptionMeta, ConverterExceptions
 from crescent.internal.registry import register_command
-from crescent.locale import LocaleBuilder
 
 if TYPE_CHECKING:
-    from typing import Any, Sequence, TypeVar
+    from collections.abc import Awaitable, Callable, Iterable
+    from typing import Any, TypeVar
 
     from crescent.internal.app_command import AppCommandMeta
     from crescent.internal.includable import Includable
+    from crescent.locale import LocaleBuilder
     from crescent.typedefs import (
         AutocompleteCallbackT,
         ClassCommandProto,
@@ -36,7 +37,7 @@ if TYPE_CHECKING:
 
     T = TypeVar("T")
 
-__all__: Sequence[str] = ("command", "user_command", "message_command")
+__all__ = ("command", "message_command", "user_command")
 
 
 def _class_command_callback(
@@ -80,10 +81,11 @@ def _class_command_callback(
 
             tasks.append((create_task(set_later(key, val)), key, raw_val))
 
+        # TODO: can we gather these tasks?
         for t, key, raw_val in tasks:
             try:
                 await t
-            except Exception as e:
+            except Exception as e:  # noqa: PERF203
                 errors.append(ConverterExceptionMeta(cls, key, raw_val, e))
 
         if errors:
@@ -171,7 +173,7 @@ def command(
             default_member_permissions=default_member_permissions,
             context_types=context_types,
             nsfw=nsfw,
-        )  # pyright: ignore
+        )  # pyright: ignore[reportReturnType]
 
     autocomplete: dict[str, AutocompleteCallbackT[Any]] = {}
     options: list[CommandOption] = []
@@ -305,7 +307,7 @@ def user_command(
             default_member_permissions=default_member_permissions,
             context_types=context_types,
             nsfw=nsfw,
-        )  # pyright: ignore
+        )  # pyright: ignore[reportReturnType]
 
     return register_command(
         callback=_kwargs_to_args_callback(callback),
@@ -386,7 +388,7 @@ def message_command(
             default_member_permissions=default_member_permissions,
             context_types=context_types,
             nsfw=nsfw,
-        )  # pyright: ignore
+        )  # pyright: ignore[reportReturnType]
 
     return register_command(
         callback=_kwargs_to_args_callback(callback),

--- a/crescent/commands/decorators.py
+++ b/crescent/commands/decorators.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from asyncio import Task, create_task
 from functools import partial, wraps
 from inspect import isawaitable, isclass, isfunction
-from typing import TYPE_CHECKING, Any, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, cast, overload
 
 from hikari import (
     UNDEFINED,
@@ -33,8 +33,6 @@ if TYPE_CHECKING:
         MessageCommandCallbackT,
         UserCommandCallbackT,
     )
-
-    T = TypeVar("T")
 
 __all__ = ("command", "message_command", "user_command")
 

--- a/crescent/commands/decorators.py
+++ b/crescent/commands/decorators.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from asyncio import Task, create_task
 from functools import partial, wraps
 from inspect import isawaitable, isclass, isfunction
-from typing import TYPE_CHECKING, cast, overload
+from typing import TYPE_CHECKING, Any, TypeVar, cast, overload
 
 from hikari import (
     UNDEFINED,
@@ -22,7 +22,6 @@ from crescent.internal.registry import register_command
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterable
-    from typing import Any, TypeVar
 
     from crescent.internal.app_command import AppCommandMeta
     from crescent.internal.includable import Includable

--- a/crescent/commands/groups.py
+++ b/crescent/commands/groups.py
@@ -1,21 +1,21 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
 
 from hikari import UNDEFINED, ApplicationContextType, Permissions, UndefinedType
 
 from crescent.exceptions import PermissionsError
 
 if TYPE_CHECKING:
-    from typing import Sequence
+    from collections.abc import Iterable
 
     from crescent.internal.app_command import AppCommandMeta
     from crescent.internal.includable import Includable
     from crescent.locale import LocaleBuilder
     from crescent.typedefs import CommandHookCallbackT
 
-__all__: Sequence[str] = ("Group", "SubGroup")
+__all__ = ("Group", "SubGroup")
 
 
 def _check_permissions(includable: Includable[AppCommandMeta]) -> None:

--- a/crescent/commands/groups.py
+++ b/crescent/commands/groups.py
@@ -23,7 +23,7 @@ def _check_permissions(includable: Includable[AppCommandMeta]) -> None:
     if includable.metadata.app_command.default_member_permissions:
         raise PermissionsError(
             "`default_member_permissions` cannot be declared for subcommands."
-            " Permissions must be declared in the `crescent.Group` object."
+            " Permissions must be declared in the `crescent.Group` object.",
         )
 
 

--- a/crescent/commands/options.py
+++ b/crescent/commands/options.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import Any, Awaitable, Callable, Generic, Sequence, TypeVar, cast, overload
-from typing_extensions import Never, Self
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, overload
 
 from hikari import (
     UNDEFINED,
@@ -19,32 +18,37 @@ from hikari import (
     UndefinedOr,
     User,
 )
+from typing_extensions import Never, Self
 
 from crescent.locale import LocaleBuilder, str_or_build_locale
-from crescent.mentionable import Mentionable
-from crescent.typedefs import AutocompleteCallbackT
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Sequence
+
+    from crescent.mentionable import Mentionable
+    from crescent.typedefs import AutocompleteCallbackT
 
 __all__ = (
-    "Marker",
-    "StrMarker",
-    "BoolMarker",
-    "IntMarker",
-    "FloatMarker",
-    "ChannelMarker",
-    "RoleMarker",
-    "UserMarker",
-    "MentionableMarker",
     "AttachmentMarker",
+    "BoolMarker",
+    "ChannelMarker",
     "ClassCommandOption",
-    "string",
-    "boolean",
-    "number",
-    "floating",
-    "channel",
-    "role",
-    "user",
-    "mentionable",
+    "FloatMarker",
+    "IntMarker",
+    "Marker",
+    "MentionableMarker",
+    "RoleMarker",
+    "StrMarker",
+    "UserMarker",
     "attachment",
+    "boolean",
+    "channel",
+    "floating",
+    "mentionable",
+    "number",
+    "role",
+    "string",
+    "user",
 )
 
 
@@ -112,7 +116,7 @@ class ClassCommandOption(Generic[MarkT, InT, ConverterT, DefaultT]):
         """Set the Discord-facing name for this option."""
         return replace(self, _name=name)
 
-    def default(self, default: T) -> "ClassCommandOption[MarkT, InT, ConverterT, T]":
+    def default(self, default: T) -> ClassCommandOption[MarkT, InT, ConverterT, T]:
         """Set a default value, making this option optional."""
         return replace(
             cast("ClassCommandOption[MarkT, InT, ConverterT, T]", self),
@@ -121,7 +125,7 @@ class ClassCommandOption(Generic[MarkT, InT, ConverterT, DefaultT]):
 
     def convert(
         self, converter: Callable[[InT], T | Awaitable[T]]
-    ) -> "ClassCommandOption[MarkT, InT, T, DefaultT]":
+    ) -> ClassCommandOption[MarkT, InT, T, DefaultT]:
         """Convert the raw option value before assigning it to the command instance."""
         return replace(
             cast("ClassCommandOption[MarkT, InT, T, DefaultT]", self),
@@ -129,27 +133,27 @@ class ClassCommandOption(Generic[MarkT, InT, ConverterT, DefaultT]):
         )
 
     def channel_types(
-        self: "ClassCommandOption[ChannelMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[ChannelMarker, InT, ConverterT, DefaultT],
         types: Sequence[ChannelType],
-    ) -> "ClassCommandOption[ChannelMarker, InT, ConverterT, DefaultT]":
+    ) -> ClassCommandOption[ChannelMarker, InT, ConverterT, DefaultT]:
         """Restrict which Discord channel types may be selected for this option."""
         return replace(self, _channel_types=types)
 
     @overload
     def autocomplete(
-        self: "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[IntMarker, InT, ConverterT, DefaultT],
         autocomplete: AutocompleteCallbackT[int],
-    ) -> "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]": ...
+    ) -> ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]: ...
     @overload
     def autocomplete(
-        self: "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT],
         autocomplete: AutocompleteCallbackT[float],
-    ) -> "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]": ...
+    ) -> ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]: ...
     @overload
     def autocomplete(
-        self: "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[StrMarker, InT, ConverterT, DefaultT],
         autocomplete: AutocompleteCallbackT[str],
-    ) -> "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]": ...
+    ) -> ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]: ...
 
     def autocomplete(self, autocomplete: AutocompleteCallbackT[Any]) -> Any:
         """Attach an autocomplete callback to this option."""
@@ -157,19 +161,19 @@ class ClassCommandOption(Generic[MarkT, InT, ConverterT, DefaultT]):
 
     @overload
     def choices(
-        self: "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[IntMarker, InT, ConverterT, DefaultT],
         choices: Sequence[tuple[str | LocaleBuilder, int] | CommandChoice],
-    ) -> "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]": ...
+    ) -> ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]: ...
     @overload
     def choices(
-        self: "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT],
         choices: Sequence[tuple[str | LocaleBuilder, float] | CommandChoice],
-    ) -> "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]": ...
+    ) -> ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]: ...
     @overload
     def choices(
-        self: "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[StrMarker, InT, ConverterT, DefaultT],
         choices: Sequence[tuple[str | LocaleBuilder, str] | CommandChoice],
-    ) -> "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]": ...
+    ) -> ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]: ...
 
     def choices(
         self, choices: Sequence[tuple[str | LocaleBuilder, int | str | float] | CommandChoice]
@@ -179,15 +183,15 @@ class ClassCommandOption(Generic[MarkT, InT, ConverterT, DefaultT]):
 
     @overload
     def min_value(
-        self: "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[IntMarker, InT, ConverterT, DefaultT],
         value: int,
-    ) -> "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]": ...
+    ) -> ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]: ...
 
     @overload
     def min_value(
-        self: "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT],
         value: float,
-    ) -> "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]": ...
+    ) -> ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]: ...
 
     def min_value(self, value: int | float) -> Any:
         """Set the inclusive minimum numeric value for this option."""
@@ -195,31 +199,31 @@ class ClassCommandOption(Generic[MarkT, InT, ConverterT, DefaultT]):
 
     @overload
     def max_value(
-        self: "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[IntMarker, InT, ConverterT, DefaultT],
         value: int,
-    ) -> "ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]": ...
+    ) -> ClassCommandOption[IntMarker, InT, ConverterT, DefaultT]: ...
 
     @overload
     def max_value(
-        self: "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT],
         value: float,
-    ) -> "ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]": ...
+    ) -> ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]: ...
 
     def max_value(self, value: int | float) -> Any:
         """Set the inclusive maximum numeric value for this option."""
         return replace(self, _max_value=value)
 
     def min_length(
-        self: "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[StrMarker, InT, ConverterT, DefaultT],
         value: int,
-    ) -> "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]":
+    ) -> ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]:
         """Set the inclusive minimum string length for this option."""
         return replace(self, _min_length=value)
 
     def max_length(
-        self: "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]",
+        self: ClassCommandOption[StrMarker, InT, ConverterT, DefaultT],
         value: int,
-    ) -> "ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]":
+    ) -> ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]:
         """Set the inclusive maximum string length for this option."""
         return replace(self, _max_length=value)
 
@@ -228,19 +232,19 @@ class ClassCommandOption(Generic[MarkT, InT, ConverterT, DefaultT]):
 
     @overload
     def __get__(
-        self: "ClassCommandOption[MarkT, InT, Never, Never]", inst: object, cls: Any
+        self: ClassCommandOption[MarkT, InT, Never, Never], inst: object, cls: Any
     ) -> InT: ...
     @overload
     def __get__(
-        self: "ClassCommandOption[MarkT, InT, ConverterT, Never]", inst: object, cls: Any
+        self: ClassCommandOption[MarkT, InT, ConverterT, Never], inst: object, cls: Any
     ) -> ConverterT: ...
     @overload
     def __get__(
-        self: "ClassCommandOption[MarkT, InT, Never, DefaultT]", inst: object, cls: Any
+        self: ClassCommandOption[MarkT, InT, Never, DefaultT], inst: object, cls: Any
     ) -> InT | DefaultT: ...
     @overload
     def __get__(
-        self: "ClassCommandOption[MarkT, InT, ConverterT, DefaultT]", inst: object, cls: Any
+        self: ClassCommandOption[MarkT, InT, ConverterT, DefaultT], inst: object, cls: Any
     ) -> ConverterT | DefaultT: ...
 
     def __get__(self, inst: Any | None, cls: Any) -> Any:

--- a/crescent/commands/options.py
+++ b/crescent/commands/options.py
@@ -193,7 +193,7 @@ class ClassCommandOption(Generic[MarkT, InT, ConverterT, DefaultT]):
         value: float,
     ) -> ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]: ...
 
-    def min_value(self, value: int | float) -> Any:
+    def min_value(self, value: float) -> Any:
         """Set the inclusive minimum numeric value for this option."""
         return replace(self, _min_value=value)
 
@@ -209,7 +209,7 @@ class ClassCommandOption(Generic[MarkT, InT, ConverterT, DefaultT]):
         value: float,
     ) -> ClassCommandOption[FloatMarker, InT, ConverterT, DefaultT]: ...
 
-    def max_value(self, value: int | float) -> Any:
+    def max_value(self, value: float) -> Any:
         """Set the inclusive maximum numeric value for this option."""
         return replace(self, _max_value=value)
 

--- a/crescent/commands/options.py
+++ b/crescent/commands/options.py
@@ -13,7 +13,6 @@ from hikari import (
     CommandOption,
     InteractionChannel,
     OptionType,
-    PartialChannel,
     Role,
     UndefinedOr,
     User,
@@ -70,7 +69,6 @@ MarkT = TypeVar("MarkT", bound=Marker)
 InT = TypeVar("InT")
 ConverterT = TypeVar("ConverterT")
 DefaultT = TypeVar("DefaultT")
-ChannelTypeT = TypeVar("ChannelTypeT", bound=PartialChannel)
 T = TypeVar("T")
 
 

--- a/crescent/commands/options.py
+++ b/crescent/commands/options.py
@@ -124,7 +124,8 @@ class ClassCommandOption(Generic[MarkT, InT, ConverterT, DefaultT]):
         )
 
     def convert(
-        self, converter: Callable[[InT], T | Awaitable[T]]
+        self,
+        converter: Callable[[InT], T | Awaitable[T]],
     ) -> ClassCommandOption[MarkT, InT, T, DefaultT]:
         """Convert the raw option value before assigning it to the command instance."""
         return replace(
@@ -176,7 +177,8 @@ class ClassCommandOption(Generic[MarkT, InT, ConverterT, DefaultT]):
     ) -> ClassCommandOption[StrMarker, InT, ConverterT, DefaultT]: ...
 
     def choices(
-        self, choices: Sequence[tuple[str | LocaleBuilder, int | str | float] | CommandChoice]
+        self,
+        choices: Sequence[tuple[str | LocaleBuilder, int | str | float] | CommandChoice],
     ) -> Any:
         """Set the fixed choices users may select for this option."""
         return replace(self, _choices=_build_choices(choices))
@@ -232,19 +234,27 @@ class ClassCommandOption(Generic[MarkT, InT, ConverterT, DefaultT]):
 
     @overload
     def __get__(
-        self: ClassCommandOption[MarkT, InT, Never, Never], inst: object, cls: Any
+        self: ClassCommandOption[MarkT, InT, Never, Never],
+        inst: object,
+        cls: Any,
     ) -> InT: ...
     @overload
     def __get__(
-        self: ClassCommandOption[MarkT, InT, ConverterT, Never], inst: object, cls: Any
+        self: ClassCommandOption[MarkT, InT, ConverterT, Never],
+        inst: object,
+        cls: Any,
     ) -> ConverterT: ...
     @overload
     def __get__(
-        self: ClassCommandOption[MarkT, InT, Never, DefaultT], inst: object, cls: Any
+        self: ClassCommandOption[MarkT, InT, Never, DefaultT],
+        inst: object,
+        cls: Any,
     ) -> InT | DefaultT: ...
     @overload
     def __get__(
-        self: ClassCommandOption[MarkT, InT, ConverterT, DefaultT], inst: object, cls: Any
+        self: ClassCommandOption[MarkT, InT, ConverterT, DefaultT],
+        inst: object,
+        cls: Any,
     ) -> ConverterT | DefaultT: ...
 
     def __get__(self, inst: Any | None, cls: Any) -> Any:
@@ -282,7 +292,8 @@ class _OptionBuilder(Generic[MarkT, InT]):
     _type: OptionType
 
     def __call__(
-        self, description: str | LocaleBuilder
+        self,
+        description: str | LocaleBuilder,
     ) -> ClassCommandOption[MarkT, InT, Never, Never]:
         """Create an option declaration with the provided description."""
         return ClassCommandOption(_description=description, _type=self._type)
@@ -296,6 +307,6 @@ channel: _OptionBuilder[ChannelMarker, InteractionChannel] = _OptionBuilder(Opti
 role: _OptionBuilder[RoleMarker, Role] = _OptionBuilder(OptionType.ROLE)
 user: _OptionBuilder[UserMarker, User] = _OptionBuilder(OptionType.USER)
 mentionable: _OptionBuilder[MentionableMarker, Mentionable] = _OptionBuilder(
-    OptionType.MENTIONABLE
+    OptionType.MENTIONABLE,
 )
 attachment: _OptionBuilder[AttachmentMarker, Attachment] = _OptionBuilder(OptionType.ATTACHMENT)

--- a/crescent/context/__init__.py
+++ b/crescent/context/__init__.py
@@ -1,7 +1,7 @@
-from typing import Sequence
+from __future__ import annotations
 
-from crescent.context.autocomplete_context import *
-from crescent.context.context import *
-from crescent.context.interaction_context import *
+from crescent.context.autocomplete_context import AutocompleteContext
+from crescent.context.context import Context
+from crescent.context.interaction_context import InteractionContext
 
-__all__: Sequence[str] = ("InteractionContext", "Context", "AutocompleteContext")
+__all__ = ("AutocompleteContext", "Context", "InteractionContext")

--- a/crescent/context/autocomplete_context.py
+++ b/crescent/context/autocomplete_context.py
@@ -40,8 +40,7 @@ async def _fetch_user(ctx: AutocompleteContext, value: Snowflake) -> User | Memb
 
 
 async def _fetch_role(ctx: AutocompleteContext, value: Snowflake) -> Role:
-    if ctx.guild_id is None:
-        raise ValueError("Cannot fetch a guild role for an interaction without a guild.")
+    assert ctx.guild_id
 
     if isinstance(ctx.app, CacheAware) and (role := ctx.app.cache.get_role(value)):
         return role
@@ -102,8 +101,7 @@ class AutocompleteContext(InteractionContext):
             if func := _serialization_map.get(OptionType(option.type)):
                 # `option.value` is a `Snowflake` or `int` for all option types
                 # in `_serialization_map`.
-                if option.value is None:
-                    raise ValueError("Autocomplete option unexpectedly had no value.")
+                assert option.value
                 out[option.name] = await func(self, Snowflake(option.value))
             else:
                 out[option.name] = option.value

--- a/crescent/context/autocomplete_context.py
+++ b/crescent/context/autocomplete_context.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Sequence
+from typing import TYPE_CHECKING, Any
 
 from hikari import (
     AutocompleteInteraction,
@@ -19,7 +19,10 @@ from crescent.context.interaction_context import InteractionContext
 from crescent.mentionable import Mentionable
 from crescent.utils import gather_iter
 
-__all__: Sequence[str] = ("AutocompleteContext",)
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+__all__ = ("AutocompleteContext",)
 
 
 async def _fetch_user(ctx: AutocompleteContext, value: Snowflake) -> User | Member:
@@ -33,16 +36,15 @@ async def _fetch_user(ctx: AutocompleteContext, value: Snowflake) -> User | Memb
 
     if ctx.guild_id:
         return await ctx.app.rest.fetch_member(ctx.guild_id, value)
-    else:
-        return await ctx.app.rest.fetch_user(value)
+    return await ctx.app.rest.fetch_user(value)
 
 
 async def _fetch_role(ctx: AutocompleteContext, value: Snowflake) -> Role:
-    assert ctx.guild_id
+    if ctx.guild_id is None:
+        raise ValueError("Cannot fetch a guild role for an interaction without a guild.")
 
-    if isinstance(ctx.app, CacheAware):
-        if role := ctx.app.cache.get_role(value):
-            return role
+    if isinstance(ctx.app, CacheAware) and (role := ctx.app.cache.get_role(value)):
+        return role
 
     roles = await ctx.app.rest.fetch_roles(ctx.guild_id)
     return next(filter(lambda r: r.id == value, roles))
@@ -66,9 +68,8 @@ async def _fetch_mentionable(ctx: AutocompleteContext, value: Snowflake) -> Ment
 
 
 async def _fetch_channel(ctx: AutocompleteContext, value: Snowflake) -> PartialChannel:
-    if isinstance(ctx.app, CacheAware):
-        if channel := ctx.app.cache.get_guild_channel(value):
-            return channel
+    if isinstance(ctx.app, CacheAware) and (channel := ctx.app.cache.get_guild_channel(value)):
+        return channel
 
     return await ctx.app.rest.fetch_channel(value)
 
@@ -101,7 +102,8 @@ class AutocompleteContext(InteractionContext):
             if func := _serialization_map.get(OptionType(option.type)):
                 # `option.value` is a `Snowflake` or `int` for all option types
                 # in `_serialization_map`.
-                assert option.value
+                if option.value is None:
+                    raise ValueError("Autocomplete option unexpectedly had no value.")
                 out[option.name] = await func(self, Snowflake(option.value))
             else:
                 out[option.name] = option.value

--- a/crescent/context/context.py
+++ b/crescent/context/context.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Union, overload
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 from hikari import (
     UNDEFINED,
@@ -22,7 +22,7 @@ from crescent.context.interaction_context import InteractionContext
 from crescent.exceptions import InteractionAlreadyAcknowledgedError
 
 if TYPE_CHECKING:
-    from typing import Any, Literal, Sequence
+    from collections.abc import Sequence
 
     from hikari import (
         Attachment,
@@ -38,11 +38,9 @@ if TYPE_CHECKING:
         UndefinedType,
     )
 
-__all__: Sequence[str] = ("Context",)
+__all__ = ("Context",)
 
-ResponseBuilderT = Union[
-    InteractionMessageBuilder, InteractionDeferredBuilder, InteractionModalBuilder
-]
+ResponseBuilderT = InteractionMessageBuilder | InteractionDeferredBuilder | InteractionModalBuilder
 
 
 class Context(InteractionContext):
@@ -204,18 +202,18 @@ class Context(InteractionContext):
             else:
                 flags |= MessageFlag.EPHEMERAL
 
-        kwargs: dict[str, Any] = dict(
-            content=content,
-            attachment=attachment,
-            attachments=attachments,
-            component=component,
-            components=components,
-            embed=embed,
-            embeds=embeds,
-            mentions_everyone=mentions_everyone,
-            user_mentions=user_mentions,
-            role_mentions=role_mentions,
-        )
+        kwargs: dict[str, Any] = {
+            "content": content,
+            "attachment": attachment,
+            "attachments": attachments,
+            "component": component,
+            "components": components,
+            "embed": embed,
+            "embeds": embeds,
+            "mentions_everyone": mentions_everyone,
+            "user_mentions": user_mentions,
+            "role_mentions": role_mentions,
+        }
 
         if not (self._has_deferred_response or self._has_created_response):
             if future := self._unset_future:

--- a/crescent/context/context.py
+++ b/crescent/context/context.py
@@ -56,7 +56,7 @@ class Context(InteractionContext):
         """
         if isinstance(self.app, CacheAware):
             return self.app.cache.get_guild_channel(self.channel_id) or self.app.cache.get_thread(
-                self.channel_id
+                self.channel_id,
             )
         return None
 
@@ -268,7 +268,10 @@ class Context(InteractionContext):
         return await self.followup(**kwargs)
 
     async def respond_with_modal(
-        self, title: str, custom_id: str, components: Sequence[ComponentBuilder]
+        self,
+        title: str,
+        custom_id: str,
+        components: Sequence[ComponentBuilder],
     ) -> None:
         """Respond to an interaction with a modal.
 
@@ -286,7 +289,7 @@ class Context(InteractionContext):
         """
         if self._has_created_response or self._has_deferred_response:
             raise InteractionAlreadyAcknowledgedError(
-                "You cannot use this method after already responding to an interaction."
+                "You cannot use this method after already responding to an interaction.",
             )
 
         if future := self._unset_future:
@@ -296,12 +299,16 @@ class Context(InteractionContext):
             future.set_result(builder)
         else:
             await self.interaction.create_modal_response(
-                title=title, custom_id=custom_id, components=components
+                title=title,
+                custom_id=custom_id,
+                components=components,
             )
         self._has_created_response = True
 
     async def respond_with_builder(
-        self, builder: ResponseBuilderT, ensure_message: bool = False
+        self,
+        builder: ResponseBuilderT,
+        ensure_message: bool = False,
     ) -> Message | None:
         """Respond to an interaction with a builder.
 
@@ -321,7 +328,7 @@ class Context(InteractionContext):
         """
         if self._has_created_response or self._has_deferred_response:
             raise InteractionAlreadyAcknowledgedError(
-                "This method cannot be used after already responding to an interaction."
+                "This method cannot be used after already responding to an interaction.",
             )
 
         if future := self._unset_future:
@@ -342,11 +349,14 @@ class Context(InteractionContext):
                 )
             elif isinstance(builder, InteractionDeferredBuilder):
                 await self.interaction.create_initial_response(
-                    response_type=ResponseType.DEFERRED_MESSAGE_CREATE, flags=builder.flags
+                    response_type=ResponseType.DEFERRED_MESSAGE_CREATE,
+                    flags=builder.flags,
                 )
             else:
                 await self.interaction.create_modal_response(
-                    title=builder.title, custom_id=builder.custom_id, components=builder.components
+                    title=builder.title,
+                    custom_id=builder.custom_id,
+                    components=builder.components,
                 )
         self._has_created_response = True
 
@@ -470,5 +480,6 @@ class Context(InteractionContext):
         ```
         """
         await self.app.rest.delete_interaction_response(
-            application=self.application_id, token=self.token
+            application=self.application_id,
+            token=self.token,
         )

--- a/crescent/context/context.py
+++ b/crescent/context/context.py
@@ -65,7 +65,7 @@ class Context(InteractionContext):
         """Get this context's guild from the cache."""
         return self.interaction.get_guild()
 
-    async def defer(self, ephemeral: bool = False) -> None:
+    async def defer(self, *, ephemeral: bool = False) -> None:
         """
         Defer this interaction response, allowing you to respond within the next 15
         minutes.
@@ -308,6 +308,7 @@ class Context(InteractionContext):
     async def respond_with_builder(
         self,
         builder: ResponseBuilderT,
+        *,
         ensure_message: bool = False,
     ) -> Message | None:
         """Respond to an interaction with a builder.

--- a/crescent/context/interaction_context.py
+++ b/crescent/context/interaction_context.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, TypeVar
 
 if TYPE_CHECKING:
     import builtins
     from asyncio import Future
     from collections.abc import Sequence
-    from typing import Any, TypeVar
 
     import hikari
     from hikari import Locale, Member, PartialInteraction, Snowflake, User

--- a/crescent/context/interaction_context.py
+++ b/crescent/context/interaction_context.py
@@ -17,6 +17,9 @@ if TYPE_CHECKING:
     ContextT = TypeVar("ContextT", bound="InteractionContext")
 
 
+__all__ = ("InteractionContext",)
+
+
 @dataclass(slots=True)
 class InteractionContext:
     """Represents the context for interactions"""

--- a/crescent/context/interaction_context.py
+++ b/crescent/context/interaction_context.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-import hikari
-from hikari import Locale, Member, PartialInteraction, Snowflake, User
-
 if TYPE_CHECKING:
+    import builtins
     from asyncio import Future
-    from typing import Any, Sequence, Type, TypeVar
+    from collections.abc import Sequence
+    from typing import Any, TypeVar
 
+    import hikari
+    from hikari import Locale, Member, PartialInteraction, Snowflake, User
     from hikari.api import InteractionResponseBuilder
 
     from crescent.client import Client, GatewayTraits, RESTTraits
@@ -17,38 +18,9 @@ if TYPE_CHECKING:
     ContextT = TypeVar("ContextT", bound="InteractionContext")
 
 
-__all__: Sequence[str] = ("InteractionContext",)
-
-
-@dataclass
+@dataclass(slots=True)
 class InteractionContext:
     """Represents the context for interactions"""
-
-    __slots__ = (
-        "interaction",
-        "app",
-        "client",
-        "application_id",
-        "type",
-        "token",
-        "id",
-        "version",
-        "channel_id",
-        "guild_id",
-        "registered_guild_id",
-        "user",
-        "member",
-        "entitlements",
-        "locale",
-        "command",
-        "command_type",
-        "group",
-        "sub_group",
-        "options",
-        "_has_created_response",
-        "_has_deferred_response",
-        "_rest_interaction_future",
-    )
 
     interaction: PartialInteraction
     """The interaction object."""
@@ -117,11 +89,10 @@ class InteractionContext:
             return self._rest_interaction_future
         return None
 
-    def into(self, context_t: Type[ContextT]) -> ContextT:
+    def into(self, context_t: builtins.type[ContextT]) -> ContextT:
         """Convert to a context of a different type."""
         if type(self) is context_t:
-            # pyright can't tell this is of type `context_t`
-            return self  # pyright: ignore
+            return self
 
         return context_t(
             interaction=self.interaction,

--- a/crescent/errors.py
+++ b/crescent/errors.py
@@ -32,7 +32,9 @@ def _make_catch_function(
 
         def decorator(callback: Any) -> Includable[Any]:
             return Includable(
-                callback, client_set_hooks=[app_set_hook], plugin_unload_hooks=[plugin_unload_hook]
+                callback,
+                client_set_hooks=[app_set_hook],
+                plugin_unload_hooks=[plugin_unload_hook],
             )
 
         return decorator
@@ -98,7 +100,8 @@ def catch_event(
 def catch_autocomplete(
     *exceptions: type[Exception],
 ) -> Callable[
-    [AutocompleteErrorHandlerCallbackT[Any]], Includable[AutocompleteErrorHandlerCallbackT[Any]]
+    [AutocompleteErrorHandlerCallbackT[Any]],
+    Includable[AutocompleteErrorHandlerCallbackT[Any]],
 ]:
     """
     Catch an exception or subclasses of an exception passed into this function when the

--- a/crescent/errors.py
+++ b/crescent/errors.py
@@ -1,22 +1,25 @@
 from __future__ import annotations
 
-from typing import Any, Awaitable, Callable, Sequence, TypeVar
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from crescent.internal.includable import Includable
-from crescent.typedefs import (
-    AutocompleteErrorHandlerCallbackT,
-    CommandErrorHandlerCallbackT,
-    EventErrorHandlerCallbackT,
-)
 
-__all__: Sequence[str] = ("catch_command", "catch_event", "catch_autocomplete")
+if TYPE_CHECKING:
+    from crescent.typedefs import (
+        AutocompleteErrorHandlerCallbackT,
+        CommandErrorHandlerCallbackT,
+        EventErrorHandlerCallbackT,
+    )
+
+__all__ = ("catch_autocomplete", "catch_command", "catch_event")
 
 
 T = TypeVar("T", bound=Callable[..., Awaitable[Any]])
 
 
 def _make_catch_function(
-    error_handler_var: str, supports_custom_ctx: bool = False
+    error_handler_var: str,
 ) -> Callable[[type[Exception]], Callable[[T], Includable[T]]]:
     def func(*exceptions: type[Exception]) -> Callable[[T], Includable[T]]:
         def app_set_hook(includable: Includable[Any]) -> None:
@@ -28,20 +31,18 @@ def _make_catch_function(
                 getattr(includable.client, error_handler_var).remove(exc)
 
         def decorator(callback: Any) -> Includable[Any]:
-            includable = Includable(
+            return Includable(
                 callback, client_set_hooks=[app_set_hook], plugin_unload_hooks=[plugin_unload_hook]
             )
-
-            return includable
 
         return decorator
 
     return func
 
 
-_catch_command = _make_catch_function("_command_error_handler", supports_custom_ctx=True)
+_catch_command = _make_catch_function("_command_error_handler")
 _catch_event = _make_catch_function("_event_error_handler")
-_catch_autocomplete = _make_catch_function("_autocomplete_error_handler", supports_custom_ctx=True)
+_catch_autocomplete = _make_catch_function("_autocomplete_error_handler")
 
 
 # NOTE: These functions are defined to help properly type the user facings functions and

--- a/crescent/events.py
+++ b/crescent/events.py
@@ -32,7 +32,11 @@ class EventMeta(Generic[EventT]):
     after_hooks: list[EventHookCallbackT[EventT]] = field(default_factory=list)  # pyright: ignore[reportUnknownVariableType]
 
     def add_hooks(
-        self, hooks: Sequence[EventHookCallbackT[Any]], prepend: bool = False, *, after: bool
+        self,
+        hooks: Sequence[EventHookCallbackT[Any]],
+        prepend: bool = False,
+        *,
+        after: bool,
     ) -> None:
         add_hooks(self.hooks, self.after_hooks, hooks, prepend=prepend, after=after)
 
@@ -43,12 +47,16 @@ def event(callback: CallbackT[EventT], /) -> Includable[EventMeta[EventT]]: ...
 
 @overload
 def event(
-    *, event_type: type[EventT] | None
+    *,
+    event_type: type[EventT] | None,
 ) -> Callable[[CallbackT[EventT]], Includable[EventMeta[EventT]]]: ...
 
 
 def event(
-    callback: CallbackT[EventT] | None = None, /, *, event_type: type[EventT] | None = None
+    callback: CallbackT[EventT] | None = None,
+    /,
+    *,
+    event_type: type[EventT] | None = None,
 ) -> Callable[[CallbackT[EventT]], Includable[EventMeta[EventT]]] | Includable[EventMeta[EventT]]:
     """
     Listen to an event. This function should be used instead of
@@ -85,11 +93,12 @@ def event(
     def hook(includable: Includable[EventMeta[EventT]]) -> None:
         if isinstance(includable.client.app, EventManagerAware):
             includable.client.app.event_manager.subscribe(
-                event_type=unwrap(event_type), callback=event_callback
+                event_type=unwrap(event_type),
+                callback=event_callback,
             )
         else:
             raise ValueError(
-                "Events can only be used with bots that implement `hikari.EventManagerAware`."
+                "Events can only be used with bots that implement `hikari.EventManagerAware`.",
             )
 
     def on_remove(includable: Includable[EventMeta[EventT]]) -> None:
@@ -97,7 +106,8 @@ def event(
         # added in the first place.
         assert isinstance(includable.client.app, EventManagerAware)
         includable.client.app.event_manager.unsubscribe(
-            event_type=unwrap(event_type), callback=event_callback
+            event_type=unwrap(event_type),
+            callback=event_callback,
         )
 
     includable = Includable(

--- a/crescent/events.py
+++ b/crescent/events.py
@@ -95,7 +95,7 @@ def event(
     def on_remove(includable: Includable[EventMeta[EventT]]) -> None:
         # if it's not `EventManagerAware`, the event could never have been
         # added in the first place.
-        assert isinstance(includable.client.app, EventManagerAware)  # noqa: S101
+        assert isinstance(includable.client.app, EventManagerAware)
         includable.client.app.event_manager.unsubscribe(
             event_type=unwrap(event_type), callback=event_callback
         )

--- a/crescent/events.py
+++ b/crescent/events.py
@@ -34,8 +34,8 @@ class EventMeta(Generic[EventT]):
     def add_hooks(
         self,
         hooks: Sequence[EventHookCallbackT[Any]],
-        prepend: bool = False,
         *,
+        prepend: bool = False,
         after: bool,
     ) -> None:
         add_hooks(self.hooks, self.after_hooks, hooks, prepend=prepend, after=after)

--- a/crescent/events.py
+++ b/crescent/events.py
@@ -19,16 +19,16 @@ if TYPE_CHECKING:
 
     from crescent.typedefs import EventHookCallbackT
 
-EventT = TypeVar("EventT", bound="Event", contravariant=True)
+EventT_contra = TypeVar("EventT_contra", bound="Event", contravariant=True)
 
 __all__ = ("event",)
 
 
 @dataclass
-class EventMeta(Generic[EventT]):
-    callback: CallbackT[EventT]
-    hooks: list[EventHookCallbackT[EventT]] = field(default_factory=list)  # pyright: ignore[reportUnknownVariableType]
-    after_hooks: list[EventHookCallbackT[EventT]] = field(default_factory=list)  # pyright: ignore[reportUnknownVariableType]
+class EventMeta(Generic[EventT_contra]):
+    callback: CallbackT[EventT_contra]
+    hooks: list[EventHookCallbackT[EventT_contra]] = field(default_factory=list)  # pyright: ignore[reportUnknownVariableType]
+    after_hooks: list[EventHookCallbackT[EventT_contra]] = field(default_factory=list)  # pyright: ignore[reportUnknownVariableType]
 
     def add_hooks(
         self,
@@ -41,22 +41,25 @@ class EventMeta(Generic[EventT]):
 
 
 @overload
-def event(callback: CallbackT[EventT], /) -> Includable[EventMeta[EventT]]: ...
+def event(callback: CallbackT[EventT_contra], /) -> Includable[EventMeta[EventT_contra]]: ...
 
 
 @overload
 def event(
     *,
-    event_type: type[EventT] | None,
-) -> Callable[[CallbackT[EventT]], Includable[EventMeta[EventT]]]: ...
+    event_type: type[EventT_contra] | None,
+) -> Callable[[CallbackT[EventT_contra]], Includable[EventMeta[EventT_contra]]]: ...
 
 
 def event(
-    callback: CallbackT[EventT] | None = None,
+    callback: CallbackT[EventT_contra] | None = None,
     /,
     *,
-    event_type: type[EventT] | None = None,
-) -> Callable[[CallbackT[EventT]], Includable[EventMeta[EventT]]] | Includable[EventMeta[EventT]]:
+    event_type: type[EventT_contra] | None = None,
+) -> (
+    Callable[[CallbackT[EventT_contra]], Includable[EventMeta[EventT_contra]]]
+    | Includable[EventMeta[EventT_contra]]
+):
     """
     Listen to an event. This function should be used instead of
     `hikari.GatewayBot.listen` whenever possible.
@@ -89,7 +92,7 @@ def event(
     if not iscoroutinefunction(callback):
         raise ValueError(f"`{callback.__name__}` must be an async function.")
 
-    def hook(includable: Includable[EventMeta[EventT]]) -> None:
+    def hook(includable: Includable[EventMeta[EventT_contra]]) -> None:
         if isinstance(includable.client.app, EventManagerAware):
             includable.client.app.event_manager.subscribe(
                 event_type=unwrap(event_type),
@@ -100,7 +103,7 @@ def event(
                 "Events can only be used with bots that implement `hikari.EventManagerAware`.",
             )
 
-    def on_remove(includable: Includable[EventMeta[EventT]]) -> None:
+    def on_remove(includable: Includable[EventMeta[EventT_contra]]) -> None:
         # if it's not `EventManagerAware`, the event could never have been
         # added in the first place.
         assert isinstance(includable.client.app, EventManagerAware)

--- a/crescent/events.py
+++ b/crescent/events.py
@@ -8,19 +8,21 @@ from typing import TYPE_CHECKING, Generic, TypeVar, get_type_hints, overload
 from hikari import EventManagerAware
 
 from crescent.internal.includable import Includable
-from crescent.typedefs import EventHookCallbackT
 from crescent.utils import add_hooks
 from crescent.utils.options import unwrap
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Coroutine, Sequence
+    from collections.abc import Callable, Coroutine, Sequence
+    from typing import Any
 
     from hikari import Event
     from hikari.api.event_manager import CallbackT
 
+    from crescent.typedefs import EventHookCallbackT
+
 EventT = TypeVar("EventT", bound="Event", contravariant=True)
 
-__all__: Sequence[str] = ("event",)
+__all__ = ("event",)
 
 
 @dataclass
@@ -69,7 +71,7 @@ def event(
     to use type annotations.
     """
     if callback is None:
-        return partial(event, event_type=event_type)  # pyright: ignore
+        return partial(event, event_type=event_type)  # pyright: ignore[reportReturnType]
 
     if not event_type:
         event_type = next(iter(get_type_hints(callback).values()))
@@ -93,7 +95,7 @@ def event(
     def on_remove(includable: Includable[EventMeta[EventT]]) -> None:
         # if it's not `EventManagerAware`, the event could never have been
         # added in the first place.
-        assert isinstance(includable.client.app, EventManagerAware)
+        assert isinstance(includable.client.app, EventManagerAware)  # noqa: S101
         includable.client.app.event_manager.unsubscribe(
             event_type=unwrap(event_type), callback=event_callback
         )

--- a/crescent/events.py
+++ b/crescent/events.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from functools import partial
 from inspect import iscoroutinefunction
-from typing import TYPE_CHECKING, Generic, TypeVar, get_type_hints, overload
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, get_type_hints, overload
 
 from hikari import EventManagerAware
 
@@ -13,7 +13,6 @@ from crescent.utils.options import unwrap
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine, Sequence
-    from typing import Any
 
     from hikari import Event
     from hikari.api.event_manager import CallbackT

--- a/crescent/exceptions.py
+++ b/crescent/exceptions.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-
     from crescent.typedefs import ClassCommandProto
 
 __all__ = (

--- a/crescent/exceptions.py
+++ b/crescent/exceptions.py
@@ -1,21 +1,23 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Sequence
+from typing import TYPE_CHECKING, Any
 
-from crescent.typedefs import ClassCommandProto
+if TYPE_CHECKING:
 
-__all__: Sequence[str] = (
-    "CrescentException",
-    "ConverterExceptions",
-    "ConverterExceptionMeta",
+    from crescent.typedefs import ClassCommandProto
+
+__all__ = (
     "AlreadyRegisteredError",
-    "PluginAlreadyLoadedError",
+    "ConverterExceptionMeta",
+    "ConverterExceptions",
+    "CrescentException",
     "PermissionsError",
+    "PluginAlreadyLoadedError",
 )
 
 
-class CrescentException(Exception):
+class CrescentException(Exception):  # noqa: N818
     """Base Exception for all exceptions Crescent throws"""
 
 

--- a/crescent/ext/cooldowns/__init__.py
+++ b/crescent/ext/cooldowns/__init__.py
@@ -23,7 +23,8 @@ async def _default_callback(ctx: Context, retry: timedelta) -> None:
     seconds = round(retry.total_seconds())
     message = "1 second" if seconds <= 1 else f"{seconds} seconds"
     await ctx.respond(
-        f"You're using this command too much! Try again in {message}.", ephemeral=True
+        f"You're using this command too much! Try again in {message}.",
+        ephemeral=True,
     )
 
 
@@ -52,7 +53,7 @@ def cooldown(
         from floodgate import FixedMapping
     except ImportError as exc:
         raise ModuleNotFoundError(
-            "`hikari-crescent[cooldowns]` must be installed to use `crescent.ext.cooldowns`."
+            "`hikari-crescent[cooldowns]` must be installed to use `crescent.ext.cooldowns`.",
         ) from exc
 
     cooldown: FixedMapping[Any] = FixedMapping(period=period, capacity=capacity)

--- a/crescent/ext/cooldowns/__init__.py
+++ b/crescent/ext/cooldowns/__init__.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from datetime import timedelta
-from typing import Any, Awaitable, Callable, Optional
-
-from hikari import Snowflake
+from typing import TYPE_CHECKING, Any
 
 from crescent import Context, HookResult
 
-__all__ = ("CooldownCallbackT", "BucketCallbackT", "cooldown")
+if TYPE_CHECKING:
+    from hikari import Snowflake
 
-CooldownCallbackT = Callable[[Context, timedelta], Awaitable[Optional[HookResult]]]
+__all__ = ("BucketCallbackT", "CooldownCallbackT", "cooldown")
+
+CooldownCallbackT = Callable[[Context, timedelta], Awaitable[HookResult | None]]
 BucketCallbackT = Callable[[Context], Any]
 
 
@@ -19,10 +21,7 @@ def _default_bucket(ctx: Context) -> Snowflake:
 
 async def _default_callback(ctx: Context, retry: timedelta) -> None:
     seconds = round(retry.total_seconds())
-    if seconds <= 1:
-        message = "1 second"
-    else:
-        message = f"{seconds} seconds"
+    message = "1 second" if seconds <= 1 else f"{seconds} seconds"
     await ctx.respond(
         f"You're using this command too much! Try again in {message}.", ephemeral=True
     )
@@ -51,10 +50,10 @@ def cooldown(
 
     try:
         from floodgate import FixedMapping
-    except ImportError:
+    except ImportError as exc:
         raise ModuleNotFoundError(
             "`hikari-crescent[cooldowns]` must be installed to use `crescent.ext.cooldowns`."
-        )
+        ) from exc
 
     cooldown: FixedMapping[Any] = FixedMapping(period=period, capacity=capacity)
 

--- a/crescent/ext/locales/__init__.py
+++ b/crescent/ext/locales/__init__.py
@@ -1,23 +1,21 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
-from typing import Sequence
 
 import hikari
-
 from crescent import LocaleBuilder
 
 try:
-    import i18n as i18n_  # type: ignore
+    import i18n as i18n_  # type: ignore[import-not-found,import-untyped]
 except ImportError:
     i18n_ = None
 
 
-__all__: Sequence[str] = ("i18n", "LocaleMap")
+__all__ = ("LocaleMap", "i18n")
 
 
 def _translate(key: str, *, locale: str | None = None) -> str:
-    return i18n_.t(key, locale=locale)  # type: ignore
+    return i18n_.t(key, locale=locale)  # type: ignore  # noqa: PGH003
 
 
 class i18n(LocaleBuilder):

--- a/crescent/ext/locales/__init__.py
+++ b/crescent/ext/locales/__init__.py
@@ -6,7 +6,7 @@ import hikari
 from crescent import LocaleBuilder
 
 try:
-    import i18n as i18n_  # type: ignore[import-not-found,import-untyped]
+    import i18n as i18n_  # type: ignore[import-untyped]
 except ImportError:
     i18n_ = None
 

--- a/crescent/ext/tasks/__init__.py
+++ b/crescent/ext/tasks/__init__.py
@@ -1,15 +1,15 @@
-from typing import Sequence
+from __future__ import annotations
 
-from crescent.ext.tasks.cron import *
-from crescent.ext.tasks.loop import *
-from crescent.ext.tasks.task import *
+from crescent.ext.tasks.cron import Cronjob, cronjob
+from crescent.ext.tasks.loop import Loop, loop
+from crescent.ext.tasks.task import Task, TaskCallbackT, TaskError
 
-__all__: Sequence[str] = (
-    "cronjob",
-    "loop",
-    "TaskCallbackT",
+__all__ = (
     "Cronjob",
     "Loop",
     "Task",
+    "TaskCallbackT",
     "TaskError",
+    "cronjob",
+    "loop",
 )

--- a/crescent/ext/tasks/cron.py
+++ b/crescent/ext/tasks/cron.py
@@ -42,6 +42,7 @@ class Cronjob(Task):
 def cronjob(
     cron: str,
     /,
+    *,
     on_startup: bool = False,
 ) -> Callable[[TaskCallbackT], Includable[Cronjob]]:
     """

--- a/crescent/ext/tasks/cron.py
+++ b/crescent/ext/tasks/cron.py
@@ -1,22 +1,27 @@
-from datetime import datetime
-from typing import Callable, Sequence
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 from crescent.ext.tasks.task import Task, TaskCallbackT
 from crescent.internal import Includable
 
-__all__: Sequence[str] = ("cronjob", "Cronjob")
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+__all__ = ("Cronjob", "cronjob")
 
 
 class Cronjob(Task):
     def __init__(self, cron: str, callback: TaskCallbackT, *, first_loop: bool) -> None:
         try:
             from croniter import croniter
-        except ImportError:
+        except ImportError as exc:
             raise ModuleNotFoundError(
                 "`hikari-crescent[cron]` must be installed to use `cooldowns.cronjob`."
-            )
+            ) from exc
 
-        self.cron: croniter = croniter(cron, datetime.now())
+        self.cron: croniter = croniter(cron, datetime.now(tz=timezone.utc))
         self.first_loop: bool = first_loop
 
         super().__init__(callback)
@@ -26,7 +31,7 @@ class Cronjob(Task):
             return 0
 
         call_next_at: datetime = self.cron.get_next(datetime)
-        time_to_next = call_next_at - datetime.now()
+        time_to_next = call_next_at - datetime.now(tz=timezone.utc)
         return time_to_next.total_seconds()
 
     def _call_next(self) -> None:

--- a/crescent/ext/tasks/cron.py
+++ b/crescent/ext/tasks/cron.py
@@ -18,7 +18,7 @@ class Cronjob(Task):
             from croniter import croniter
         except ImportError as exc:
             raise ModuleNotFoundError(
-                "`hikari-crescent[cron]` must be installed to use `cooldowns.cronjob`."
+                "`hikari-crescent[cron]` must be installed to use `cooldowns.cronjob`.",
             ) from exc
 
         self.cron: croniter = croniter(cron, datetime.now(tz=timezone.utc))
@@ -40,7 +40,9 @@ class Cronjob(Task):
 
 
 def cronjob(
-    cron: str, /, on_startup: bool = False
+    cron: str,
+    /,
+    on_startup: bool = False,
 ) -> Callable[[TaskCallbackT], Includable[Cronjob]]:
     """
     Run a task at the time specified by the cron schedule expression.

--- a/crescent/ext/tasks/loop.py
+++ b/crescent/ext/tasks/loop.py
@@ -31,7 +31,11 @@ class Loop(Task):
 
     @overload
     def set_interval(
-        self, *, hours: int = ..., minutes: int = ..., seconds: int = ...
+        self,
+        *,
+        hours: int = ...,
+        minutes: int = ...,
+        seconds: int = ...,
     ) -> None: ...
 
     @overload
@@ -93,7 +97,11 @@ def loop(timedelta: _timedelta, /) -> LoopFactoryT: ...
 
 
 def loop(
-    timedelta: _timedelta | None = None, *, hours: int = 0, minutes: int = 0, seconds: int = 0
+    timedelta: _timedelta | None = None,
+    *,
+    hours: int = 0,
+    minutes: int = 0,
+    seconds: int = 0,
 ) -> LoopFactoryT:
     """
     Run a callback when the bot is started and every time the specified

--- a/crescent/ext/tasks/loop.py
+++ b/crescent/ext/tasks/loop.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import timedelta as _timedelta
-from typing import Callable, Sequence, overload
+from typing import overload
 
 from crescent.ext.tasks.task import Task, TaskCallbackT
 from crescent.internal import Includable
 
-__all__: Sequence[str] = ("loop", "Loop")
+__all__ = ("Loop", "loop")
 
 
 class Loop(Task):
@@ -80,20 +81,20 @@ class Loop(Task):
             self.start()
 
 
-retT = Callable[[TaskCallbackT], Includable[Loop]]
+LoopFactoryT = Callable[[TaskCallbackT], Includable[Loop]]
 
 
 @overload
-def loop(*, hours: int = ..., minutes: int = ..., seconds: int = ...) -> retT: ...
+def loop(*, hours: int = ..., minutes: int = ..., seconds: int = ...) -> LoopFactoryT: ...
 
 
 @overload
-def loop(timedelta: _timedelta, /) -> retT: ...
+def loop(timedelta: _timedelta, /) -> LoopFactoryT: ...
 
 
 def loop(
     timedelta: _timedelta | None = None, *, hours: int = 0, minutes: int = 0, seconds: int = 0
-) -> retT:
+) -> LoopFactoryT:
     """
     Run a callback when the bot is started and every time the specified
     time interval has passed.

--- a/crescent/ext/tasks/task.py
+++ b/crescent/ext/tasks/task.py
@@ -33,13 +33,11 @@ class Task(ABC):
         if self.running:
             raise TaskError("Task is already running.")
 
-        if self.client is None:
-            raise TaskError("Task is not registered to a client.")
+        assert self.client is not None
         self.client._run_future(self._start_inner())
 
     async def _start_inner(self) -> None:
-        if self.client is None:
-            raise TaskError("Task is not registered to a client.")
+        assert self.client is not None
 
         self.event_loop = get_running_loop()
         self._call_next()
@@ -59,8 +57,7 @@ class Task(ABC):
         self._call_next()
 
     def _call_next(self) -> None:
-        if self.event_loop is None:
-            raise TaskError("Task does not have an active event loop.")
+        assert self.event_loop
         self.timer_handle = self.event_loop.call_later(self._next_iteration(), self._call_async)
 
     @abstractmethod

--- a/crescent/ext/tasks/task.py
+++ b/crescent/ext/tasks/task.py
@@ -2,19 +2,21 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from asyncio import TimerHandle, get_running_loop
-from typing import TYPE_CHECKING, Awaitable, Callable, Sequence, TypeVar
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, TypeVar
 
-from crescent.client import Client
 from crescent.exceptions import CrescentException
-from crescent.internal.includable import Includable
 from crescent.utils import create_task
 
 if TYPE_CHECKING:
     from asyncio import AbstractEventLoop
 
+    from crescent.client import Client
+    from crescent.internal.includable import Includable
+
 TaskCallbackT = Callable[[], Awaitable[None]]
 
-__all__: Sequence[str] = ("TaskCallbackT", "Task", "TaskError")
+__all__ = ("Task", "TaskCallbackT", "TaskError")
 
 
 class TaskError(CrescentException): ...
@@ -31,11 +33,13 @@ class Task(ABC):
         if self.running:
             raise TaskError("Task is already running.")
 
-        assert self.client
+        if self.client is None:
+            raise TaskError("Task is not registered to a client.")
         self.client._run_future(self._start_inner())
 
     async def _start_inner(self) -> None:
-        assert self.client is not None
+        if self.client is None:
+            raise TaskError("Task is not registered to a client.")
 
         self.event_loop = get_running_loop()
         self._call_next()
@@ -55,7 +59,8 @@ class Task(ABC):
         self._call_next()
 
     def _call_next(self) -> None:
-        assert self.event_loop
+        if self.event_loop is None:
+            raise TaskError("Task does not have an active event loop.")
         self.timer_handle = self.event_loop.call_later(self._next_iteration(), self._call_async)
 
     @abstractmethod

--- a/crescent/hooks.py
+++ b/crescent/hooks.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Generic, Sequence, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, overload
 
 from hikari import Event
 
@@ -9,13 +9,15 @@ from crescent.events import EventMeta
 from crescent.internal.app_command import AppCommandMeta
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from crescent.internal.includable import Includable
     from crescent.typedefs import CommandHookCallbackT, EventHookCallbackT
 
 IncludableT = TypeVar("IncludableT")
 EventT = TypeVar("EventT", bound=Event, contravariant=True)
 
-__all__: Sequence[str] = ("HookResult", "hook")
+__all__ = ("HookResult", "hook")
 
 
 @dataclass
@@ -67,7 +69,7 @@ def hook(
 
 
 class _Hook(Generic[IncludableT]):
-    def __init__(self, callbacks: Any, after: bool):
+    def __init__(self, callbacks: Any, after: bool) -> None:
         self.callbacks = callbacks
         self.after = after
 

--- a/crescent/hooks.py
+++ b/crescent/hooks.py
@@ -67,11 +67,11 @@ def hook(
     Args:
         after: If true, run this hook after the command or event has completed.
     """
-    return _Hook(callbacks, after)
+    return _Hook(callbacks, after=after)
 
 
 class _Hook(Generic[IncludableT]):
-    def __init__(self, callbacks: Any, after: bool) -> None:
+    def __init__(self, callbacks: Any, *, after: bool) -> None:
         self.callbacks = callbacks
         self.after = after
 

--- a/crescent/hooks.py
+++ b/crescent/hooks.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from crescent.typedefs import CommandHookCallbackT, EventHookCallbackT
 
 IncludableT = TypeVar("IncludableT")
-EventT = TypeVar("EventT", bound=Event, contravariant=True)
+EventT_contra = TypeVar("EventT_contra", bound=Event, contravariant=True)
 
 __all__ = ("HookResult", "hook")
 
@@ -39,13 +39,13 @@ def hook(*callbacks: CommandHookCallbackT, after: bool = False) -> _Hook[AppComm
 
 @overload
 def hook(
-    *callbacks: EventHookCallbackT[EventT],
+    *callbacks: EventHookCallbackT[EventT_contra],
     after: bool = False,
-) -> _Hook[EventMeta[EventT]]: ...
+) -> _Hook[EventMeta[EventT_contra]]: ...
 
 
 def hook(
-    *callbacks: CommandHookCallbackT | EventHookCallbackT[EventT],
+    *callbacks: CommandHookCallbackT | EventHookCallbackT[EventT_contra],
     after: bool = False,
 ) -> _Hook[Any]:
     # TODO: Example for events
@@ -83,9 +83,9 @@ class _Hook(Generic[IncludableT]):
 
     @overload
     def __call__(
-        self: _Hook[EventMeta[EventT]],
-        obj: Includable[EventMeta[EventT]],
-    ) -> Includable[EventMeta[EventT]]: ...
+        self: _Hook[EventMeta[EventT_contra]],
+        obj: Includable[EventMeta[EventT_contra]],
+    ) -> Includable[EventMeta[EventT_contra]]: ...
 
     def __call__(self, obj: Includable[Any]) -> Includable[Any]:
         if isinstance(obj.metadata, AppCommandMeta):

--- a/crescent/hooks.py
+++ b/crescent/hooks.py
@@ -39,12 +39,14 @@ def hook(*callbacks: CommandHookCallbackT, after: bool = False) -> _Hook[AppComm
 
 @overload
 def hook(
-    *callbacks: EventHookCallbackT[EventT], after: bool = False
+    *callbacks: EventHookCallbackT[EventT],
+    after: bool = False,
 ) -> _Hook[EventMeta[EventT]]: ...
 
 
 def hook(
-    *callbacks: CommandHookCallbackT | EventHookCallbackT[EventT], after: bool = False
+    *callbacks: CommandHookCallbackT | EventHookCallbackT[EventT],
+    after: bool = False,
 ) -> _Hook[Any]:
     # TODO: Example for events
     """
@@ -75,12 +77,14 @@ class _Hook(Generic[IncludableT]):
 
     @overload
     def __call__(
-        self: _Hook[AppCommandMeta], obj: Includable[AppCommandMeta]
+        self: _Hook[AppCommandMeta],
+        obj: Includable[AppCommandMeta],
     ) -> Includable[AppCommandMeta]: ...
 
     @overload
     def __call__(
-        self: _Hook[EventMeta[EventT]], obj: Includable[EventMeta[EventT]]
+        self: _Hook[EventMeta[EventT]],
+        obj: Includable[EventMeta[EventT]],
     ) -> Includable[EventMeta[EventT]]: ...
 
     def __call__(self, obj: Includable[Any]) -> Includable[Any]:

--- a/crescent/internal/__init__.py
+++ b/crescent/internal/__init__.py
@@ -1,15 +1,14 @@
-from typing import Sequence
+from __future__ import annotations
 
-from .app_command import *
-from .handle_resp import *
-from .includable import *
-from .registry import *
+from .app_command import AppCommand, AppCommandMeta, Unique
+from .includable import Includable
+from .registry import CommandHandler, register_command
 
-__all__: Sequence[str] = (
-    "AppCommandMeta",
+__all__ = (
     "AppCommand",
-    "Unique",
-    "Includable",
-    "register_command",
+    "AppCommandMeta",
     "CommandHandler",
+    "Includable",
+    "Unique",
+    "register_command",
 )

--- a/crescent/internal/app_command.py
+++ b/crescent/internal/app_command.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any
 
 from hikari import (
     UNDEFINED,
@@ -25,8 +25,6 @@ if TYPE_CHECKING:
     from crescent.commands.groups import Group, SubGroup
     from crescent.internal.includable import Includable
     from crescent.typedefs import AutocompleteCallbackT, CommandCallbackT, CommandHookCallbackT
-
-    Self = TypeVar("Self")
 
 
 @dataclass(frozen=True)

--- a/crescent/internal/app_command.py
+++ b/crescent/internal/app_command.py
@@ -163,8 +163,8 @@ class AppCommandMeta:
     def add_hooks(
         self,
         hooks: Sequence[CommandHookCallbackT],
-        prepend: bool = False,
         *,
+        prepend: bool = False,
         after: bool,
     ) -> None:
         add_hooks(self.hooks, self.after_hooks, hooks, prepend=prepend, after=after)

--- a/crescent/internal/app_command.py
+++ b/crescent/internal/app_command.py
@@ -97,7 +97,7 @@ class AppCommand:
                     description != other.description,
                     (self.options or None) != (other.options or None),
                     description_localizations != other.description_localizations,
-                )
+                ),
             ):
                 return False
 
@@ -112,7 +112,7 @@ class AppCommand:
                 name_localizations == other.name_localizations,
                 context_types == set(other.context_types),
                 other.default_member_permissions == self.build_default_member_perms() or 0,
-            )
+            ),
         )
 
     def build_default_member_perms(self) -> Permissions | None:
@@ -161,7 +161,11 @@ class AppCommandMeta:
     after_hooks: list[CommandHookCallbackT] = field(default_factory=list)  # pyright: ignore[reportUnknownVariableType]
 
     def add_hooks(
-        self, hooks: Sequence[CommandHookCallbackT], prepend: bool = False, *, after: bool
+        self,
+        hooks: Sequence[CommandHookCallbackT],
+        prepend: bool = False,
+        *,
+        after: bool,
     ) -> None:
         add_hooks(self.hooks, self.after_hooks, hooks, prepend=prepend, after=after)
 

--- a/crescent/internal/app_command.py
+++ b/crescent/internal/app_command.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Iterable, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from hikari import (
     UNDEFINED,
@@ -12,15 +12,15 @@ from hikari import (
     SlashCommand,
     Snowflakeish,
 )
-from hikari.api import EntityFactory
 
 from crescent.locale import LocaleBuilder, str_or_build_locale
 from crescent.utils import add_hooks
 
 if TYPE_CHECKING:
-    from typing import Any, Sequence, Type
+    from collections.abc import Iterable, Sequence
 
     from hikari import CommandType, Snowflake, UndefinedOr, UndefinedType
+    from hikari.api import EntityFactory
 
     from crescent.commands.groups import Group, SubGroup
     from crescent.internal.includable import Includable
@@ -38,7 +38,7 @@ class Unique:
     sub_group: str | None
 
     @classmethod
-    def from_meta_struct(cls: Type[Unique], command: Includable[AppCommandMeta]) -> Unique:
+    def from_meta_struct(cls, command: Includable[AppCommandMeta]) -> Unique:
         return cls(
             name=str_or_build_locale(command.metadata.app_command.name)[0],
             type=command.metadata.app_command.type,
@@ -52,7 +52,7 @@ class Unique:
         )
 
     @classmethod
-    def from_app_command_meta(cls: Type[Unique], command: AppCommandMeta) -> Unique:
+    def from_app_command_meta(cls, command: AppCommandMeta) -> Unique:
         return cls(
             name=str_or_build_locale(command.app_command.name)[0],
             type=command.app_command.type,
@@ -64,7 +64,7 @@ class Unique:
         )
 
 
-__all__: Sequence[str] = ("AppCommandMeta", "AppCommand")
+__all__ = ("AppCommand", "AppCommandMeta")
 
 
 @dataclass
@@ -111,7 +111,7 @@ class AppCommand:
                 name == other.name,
                 name_localizations == other.name_localizations,
                 context_types == set(other.context_types),
-                self.build_default_member_perms() or 0 == other.default_member_permissions,
+                other.default_member_permissions == self.build_default_member_perms() or 0,
             )
         )
 

--- a/crescent/internal/app_command.py
+++ b/crescent/internal/app_command.py
@@ -27,6 +27,9 @@ if TYPE_CHECKING:
     from crescent.typedefs import AutocompleteCallbackT, CommandCallbackT, CommandHookCallbackT
 
 
+__all__ = ("AppCommand", "AppCommandMeta")
+
+
 @dataclass(frozen=True)
 class Unique:
     name: str
@@ -60,9 +63,6 @@ class Unique:
             if command.sub_group
             else None,
         )
-
-
-__all__ = ("AppCommand", "AppCommandMeta")
 
 
 @dataclass

--- a/crescent/internal/handle_resp.py
+++ b/crescent/internal/handle_resp.py
@@ -50,14 +50,19 @@ async def handle_resp(
     command_name, group, sub_group, _ = _get_crescent_command_data(interaction)
 
     command = _get_command(
-        client, command_name, interaction.command_type, interaction.guild_id, group, sub_group
+        client,
+        command_name,
+        interaction.command_type,
+        interaction.guild_id,
+        group,
+        sub_group,
     )
 
     if not command:
         if not client.allow_unknown_interactions:
             _log.warning(
                 f"Handler for command `{command_name}` does not exist locally. (If this is"
-                " intended, add `allow_unknown_interactions=True` to the Client's constructor.)"
+                " intended, add `allow_unknown_interactions=True` to the Client's constructor.)",
             )
         return
 
@@ -95,7 +100,8 @@ async def _handle_slash_resp(command: Includable[AppCommandMeta], ctx: Context) 
 
 
 async def _handle_autocomplete_resp(
-    command: Includable[AppCommandMeta], ctx: AutocompleteContext
+    command: Includable[AppCommandMeta],
+    ctx: AutocompleteContext,
 ) -> None:
     if not command.metadata.autocomplete:
         return
@@ -114,10 +120,14 @@ async def _handle_autocomplete_resp(
             await ctx.interaction.create_response(choices)
     except Exception as exc:
         handled = await command.client._autocomplete_error_handler.try_handle(
-            exc, [exc, ctx, option]
+            exc,
+            [exc, ctx, option],
         )
         await command.client.on_crescent_autocomplete_error(
-            exc, ctx.into(AutocompleteContext), option, handled
+            exc,
+            ctx.into(AutocompleteContext),
+            option,
+            handled,
         )
 
 
@@ -195,12 +205,16 @@ def _get_crescent_command_data(
             options = unwrap(option.options)[0].options
 
     return CrescentCommandData(
-        command_name=command_name, group=group, sub_group=sub_group, options=options
+        command_name=command_name,
+        group=group,
+        sub_group=sub_group,
+        options=options,
     )
 
 
 def _context_from_interaction_resp(
-    client: Client, interaction: CommandInteraction | AutocompleteInteraction
+    client: Client,
+    interaction: CommandInteraction | AutocompleteInteraction,
 ) -> Context:
     command_name, group, sub_group, options = _get_crescent_command_data(interaction)
 
@@ -264,7 +278,8 @@ def _get_resolved(interaction: CommandInteraction, option_type: int) -> Any | No
 
 
 def _extract_value(
-    option: CommandInteractionOption, interaction: CommandInteraction | AutocompleteInteraction
+    option: CommandInteractionOption,
+    interaction: CommandInteraction | AutocompleteInteraction,
 ) -> Any:
     # `option.value` is guaranteed to have a value because this is not a command group.
     if option.value is None:
@@ -296,5 +311,5 @@ def _resolved_data_to_kwargs(interaction: CommandInteraction) -> dict[str, Messa
         return {"user": next(iter(interaction.resolved.users.values()))}
 
     raise AttributeError(
-        "interaction.resolved did not have property `messages`, `members`, or `users`"
+        "interaction.resolved did not have property `messages`, `members`, or `users`",
     )

--- a/crescent/internal/handle_resp.py
+++ b/crescent/internal/handle_resp.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from asyncio import Future
 from contextlib import suppress
 from logging import getLogger
 from typing import TYPE_CHECKING, NamedTuple
@@ -15,7 +14,6 @@ from hikari import (
     OptionType,
     Snowflake,
 )
-from hikari.api import InteractionResponseBuilder
 from hikari.impl import AutocompleteChoiceBuilder
 
 from crescent.context import AutocompleteContext, Context
@@ -24,9 +22,12 @@ from crescent.mentionable import Mentionable
 from crescent.utils import unwrap
 
 if TYPE_CHECKING:
-    from typing import Any, Sequence
+    from asyncio import Future
+    from collections.abc import Sequence
+    from typing import Any
 
     from hikari import CommandInteractionOption, Message, PartialInteraction, User
+    from hikari.api import InteractionResponseBuilder
 
     from crescent.client import Client
     from crescent.internal import AppCommandMeta, Includable
@@ -35,7 +36,7 @@ if TYPE_CHECKING:
 
 _log = getLogger(__name__)
 
-__all__: Sequence[str] = ("handle_resp",)
+__all__ = ("handle_resp",)
 
 
 async def handle_resp(
@@ -43,7 +44,7 @@ async def handle_resp(
     interaction: PartialInteraction,
     future: Future[InteractionResponseBuilder] | None,
 ) -> None:
-    if not isinstance(interaction, (CommandInteraction, AutocompleteInteraction)):
+    if not isinstance(interaction, CommandInteraction | AutocompleteInteraction):
         return
 
     command_name, group, sub_group, _ = _get_crescent_command_data(interaction)
@@ -136,12 +137,17 @@ def _get_option_recursive(
 def _get_command(
     client: Client,
     name: str,
-    type: CommandType | int,
+    command_type: CommandType | int,
     guild_id: Snowflake | None,
     group: str | None,
     sub_group: str | None,
 ) -> Includable[AppCommandMeta] | None:
-    kwargs: dict[str, Any] = dict(name=name, type=type, group=group, sub_group=sub_group)
+    kwargs: dict[str, Any] = {
+        "name": name,
+        "type": command_type,
+        "group": group,
+        "sub_group": sub_group,
+    }
 
     with suppress(KeyError):
         return client._command_handler._get(Unique(guild_id=guild_id, **kwargs))
@@ -203,7 +209,8 @@ def _context_from_interaction_resp(
     else:
         # This will never be `AutocompleteInteraction` because message and user
         # commands don't have autocomplete.
-        assert isinstance(interaction, CommandInteraction)
+        if not isinstance(interaction, CommandInteraction):
+            raise TypeError("Autocomplete interactions are only valid for slash commands.")
         callback_options = _resolved_data_to_kwargs(interaction)
 
     return Context(
@@ -260,7 +267,8 @@ def _extract_value(
     option: CommandInteractionOption, interaction: CommandInteraction | AutocompleteInteraction
 ) -> Any:
     # `option.value` is guaranteed to have a value because this is not a command group.
-    assert option.value is not None
+    if option.value is None:
+        raise ValueError("Command option unexpectedly had no value.")
 
     if isinstance(interaction, AutocompleteInteraction):
         return option.value

--- a/crescent/internal/handle_resp.py
+++ b/crescent/internal/handle_resp.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from contextlib import suppress
 from logging import getLogger
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from hikari import (
     AutocompleteInteraction,
@@ -24,7 +24,6 @@ from crescent.utils import unwrap
 if TYPE_CHECKING:
     from asyncio import Future
     from collections.abc import Sequence
-    from typing import Any
 
     from hikari import CommandInteractionOption, Message, PartialInteraction, User
     from hikari.api import InteractionResponseBuilder

--- a/crescent/internal/handle_resp.py
+++ b/crescent/internal/handle_resp.py
@@ -223,8 +223,7 @@ def _context_from_interaction_resp(
     else:
         # This will never be `AutocompleteInteraction` because message and user
         # commands don't have autocomplete.
-        if not isinstance(interaction, CommandInteraction):
-            raise TypeError("Autocomplete interactions are only valid for slash commands.")
+        assert isinstance(interaction, CommandInteraction)
         callback_options = _resolved_data_to_kwargs(interaction)
 
     return Context(
@@ -282,8 +281,7 @@ def _extract_value(
     interaction: CommandInteraction | AutocompleteInteraction,
 ) -> Any:
     # `option.value` is guaranteed to have a value because this is not a command group.
-    if option.value is None:
-        raise ValueError("Command option unexpectedly had no value.")
+    assert option.value is not None
 
     if isinstance(interaction, AutocompleteInteraction):
         return option.value

--- a/crescent/internal/includable.py
+++ b/crescent/internal/includable.py
@@ -10,20 +10,20 @@ if TYPE_CHECKING:
 
     from crescent.client import Client
 
-T = TypeVar("T", contravariant=True)
+T_contra = TypeVar("T_contra", contravariant=True)
 
 __all__ = ("Includable",)
 
 
 @dataclass
-class Includable(Generic[T]):
-    metadata: T
+class Includable(Generic[T_contra]):
+    metadata: T_contra
 
     manager: Any | None = None
     _client: Client | None = None
 
-    client_set_hooks: list[Callable[[Includable[T]], None]] = field(default_factory=list)  # pyright: ignore[reportUnknownVariableType]
-    plugin_unload_hooks: list[Callable[[Includable[T]], None]] = field(default_factory=list)  # pyright: ignore[reportUnknownVariableType]
+    client_set_hooks: list[Callable[[Includable[T_contra]], None]] = field(default_factory=list)  # pyright: ignore[reportUnknownVariableType]
+    plugin_unload_hooks: list[Callable[[Includable[T_contra]], None]] = field(default_factory=list)  # pyright: ignore[reportUnknownVariableType]
 
     @property
     def client(self) -> Client:

--- a/crescent/internal/includable.py
+++ b/crescent/internal/includable.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from crescent.utils.options import unwrap
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from typing import Any
 
     from crescent.client import Client
 

--- a/crescent/internal/includable.py
+++ b/crescent/internal/includable.py
@@ -6,13 +6,14 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 from crescent.utils.options import unwrap
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Sequence
+    from collections.abc import Callable
+    from typing import Any
 
     from crescent.client import Client
 
 T = TypeVar("T", contravariant=True)
 
-__all__: Sequence[str] = ("Includable",)
+__all__ = ("Includable",)
 
 
 @dataclass

--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -104,7 +104,7 @@ class ErrorHandler(Generic[_E]):
             raise AlreadyRegisteredError(
                 f"`{includable.metadata.__name__}` can not catch `{exc.__name__}`."
                 f" `{exc.__name__}` is already registered to"
-                f" `{reg_includable.metadata.__name__}`."
+                f" `{reg_includable.metadata.__name__}`.",
             )
 
         self.registry[exc] = includable
@@ -203,7 +203,7 @@ class CommandHandler:
 
                 name, name_localizations = str_or_build_locale(command.metadata.sub_group.name)
                 description, description_localizations = str_or_build_locale(
-                    command.metadata.sub_group.description or "No Description"
+                    command.metadata.sub_group.description or "No Description",
                 )
 
                 sub_command_group = CommandOption(
@@ -231,7 +231,7 @@ class CommandHandler:
 
                 name, name_localizations = str_or_build_locale(command.metadata.app_command.name)
                 description, description_localizations = str_or_build_locale(
-                    command.metadata.app_command.description or "No Description"
+                    command.metadata.app_command.description or "No Description",
                 )
 
                 cast("list[CommandOption]", sub_command_group.options).append(
@@ -243,7 +243,7 @@ class CommandHandler:
                         type=OptionType.SUB_COMMAND,
                         options=command.metadata.app_command.options,
                         is_required=False,
-                    )
+                    ),
                 )
 
             elif command.metadata.group:
@@ -281,7 +281,7 @@ class CommandHandler:
                 # lowest level.
                 name, name_localizations = str_or_build_locale(command.metadata.app_command.name)
                 description, description_localizations = str_or_build_locale(
-                    command.metadata.app_command.description or "No Description"
+                    command.metadata.app_command.description or "No Description",
                 )
 
                 cast("list[CommandOption]", built_commands[key].options).append(
@@ -293,7 +293,7 @@ class CommandHandler:
                         type=command.metadata.app_command.type,
                         options=command.metadata.app_command.options,
                         is_required=False,
-                    )
+                    ),
                 )
 
             else:
@@ -302,14 +302,16 @@ class CommandHandler:
         return tuple(built_commands.values())
 
     async def __post_application_commands(
-        self, commands: Sequence[AppCommand], guild: UndefinedOr[Snowflakeish]
+        self,
+        commands: Sequence[AppCommand],
+        guild: UndefinedOr[Snowflakeish],
     ) -> None:
         try:
             if self._application_id is None:
                 raise AttributeError("Client `application_id` is not defined")
 
             existing_commands = await self._client.app.rest.fetch_application_commands(
-                application=self._application_id
+                application=self._application_id,
             )
 
             def exists(command: AppCommand) -> bool:
@@ -423,7 +425,9 @@ class CommandHandler:
             ),
             gather_iter(
                 self._client.app.rest.set_application_commands(
-                    application=self._application_id, commands=[], guild=guild
+                    application=self._application_id,
+                    commands=[],
+                    guild=guild,
                 )
                 for guild in guilds
             ),

--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -4,7 +4,7 @@ from asyncio import gather
 from collections import defaultdict
 from inspect import iscoroutinefunction
 from logging import getLogger
-from typing import TYPE_CHECKING, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
 from hikari import (
     UNDEFINED,
@@ -28,7 +28,6 @@ from crescent.utils import gather_iter, unwrap
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterable, Sequence
-    from typing import Any
 
     from hikari import PartialGuild, Snowflakeish, SnowflakeishOr
 

--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -27,7 +27,8 @@ from crescent.locale import LocaleBuilder, str_or_build_locale
 from crescent.utils import gather_iter, unwrap
 
 if TYPE_CHECKING:
-    from typing import Any, Awaitable, Callable, DefaultDict, Iterable, Sequence
+    from collections.abc import Awaitable, Callable, Iterable, Sequence
+    from typing import Any
 
     from hikari import PartialGuild, Snowflakeish, SnowflakeishOr
 
@@ -57,9 +58,11 @@ def register_command(
     options: Sequence[CommandOption] | None = None,
     default_member_permissions: UndefinedType | int | Permissions = UNDEFINED,
     context_types: UndefinedOr[Iterable[ApplicationContextType]] = UNDEFINED,
-    autocomplete: dict[str, AutocompleteCallbackT[Any]] = {},
+    autocomplete: dict[str, AutocompleteCallbackT[Any]] | None = None,
     nsfw: bool | None = None,
 ) -> Includable[AppCommandMeta]:
+    if autocomplete is None:
+        autocomplete = {}
     if not iscoroutinefunction(callback):
         raise ValueError(f"`{callback.__name__}` must be an async function.")
 
@@ -90,7 +93,7 @@ _E = TypeVar("_E", bound="Callable[..., Awaitable[Any]]")
 
 
 class ErrorHandler(Generic[_E]):
-    __slots__: Sequence[str] = ("bot", "registry", "subclass_registry", "supports_custom_ctx")
+    __slots__ = ("bot", "registry", "subclass_registry", "supports_custom_ctx")
 
     def __init__(self) -> None:
         self.registry: dict[type[Exception], Includable[_E]] = {}
@@ -99,7 +102,7 @@ class ErrorHandler(Generic[_E]):
     def register(self, includable: Includable[_E], exc: type[Exception]) -> None:
         if reg_includable := self.registry.get(exc):
             raise AlreadyRegisteredError(
-                f"`{getattr(includable.metadata, '__name__')}` can not catch `{exc.__name__}`."
+                f"`{includable.metadata.__name__}` can not catch `{exc.__name__}`."
                 f" `{exc.__name__}` is already registered to"
                 f" `{reg_includable.metadata.__name__}`."
             )
@@ -131,7 +134,7 @@ class ErrorHandler(Generic[_E]):
 
 
 class CommandHandler:
-    __slots__: Sequence[str] = ("_client", "_guilds", "_application_id", "_registry")
+    __slots__ = ("_application_id", "_client", "_guilds", "_registry")
 
     def __init__(self, client: Client, guilds: Sequence[Snowflakeish]) -> None:
         self._client: Client = client
@@ -229,9 +232,8 @@ class CommandHandler:
                     children.append(sub_command_group)
 
                 name, name_localizations = str_or_build_locale(command.metadata.app_command.name)
-                assert command.metadata.app_command.description
                 description, description_localizations = str_or_build_locale(
-                    command.metadata.app_command.description
+                    unwrap(command.metadata.app_command.description)
                 )
 
                 cast("list[CommandOption]", sub_command_group.options).append(
@@ -280,9 +282,8 @@ class CommandHandler:
                 # No checking has to be done before appending `command` since it is the
                 # lowest level.
                 name, name_localizations = str_or_build_locale(command.metadata.app_command.name)
-                assert command.metadata.app_command.description
                 description, description_localizations = str_or_build_locale(
-                    command.metadata.app_command.description
+                    unwrap(command.metadata.app_command.description)
                 )
 
                 cast("list[CommandOption]", built_commands[key].options).append(
@@ -332,14 +333,13 @@ class CommandHandler:
                 else:
                     _log.info("No global application commands need to be updated.")
                 return
-            else:
-                _log.info(f"Outdated commands: {', '.join(missing)}")
-                _log.info(f"Already updated: {', '.join(updated)}")
+            _log.info(f"Outdated commands: {', '.join(missing)}")
+            _log.info(f"Already updated: {', '.join(updated)}")
 
             await self._client.app.rest.set_application_commands(
                 application=self._application_id,
                 # The only method that is called has been implemented.
-                commands=commands,  # type: ignore
+                commands=commands,  # type: ignore[arg-type]
                 guild=guild,
             )
             if guild:
@@ -392,10 +392,7 @@ class CommandHandler:
             await self._client.app.rest.set_application_commands(self._application_id, ())
 
         guilds_to_purge: Iterable[PartialGuild | Snowflake | int]
-        if purge_everything:
-            guilds_to_purge = {*guilds, *self._guilds}
-        else:
-            guilds_to_purge = guilds
+        guilds_to_purge = {*guilds, *self._guilds} if purge_everything else guilds
 
         for guild in guilds_to_purge:
             await self._client.app.rest.set_application_commands(self._application_id, (), guild)
@@ -405,7 +402,7 @@ class CommandHandler:
 
         commands = self.__build_commands()
 
-        command_guilds: DefaultDict[Snowflakeish, list[AppCommand]] = defaultdict(list)
+        command_guilds: defaultdict[Snowflakeish, list[AppCommand]] = defaultdict(list)
         global_commands: list[AppCommand] = []
 
         for command in commands:

--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -201,11 +201,9 @@ class CommandHandler:
 
                 children = cast("list[CommandOption]", unwrap(built_commands[key].options))
 
-                name, name_localizations = str_or_build_locale(
-                    unwrap(command.metadata.sub_group).name
-                )
+                name, name_localizations = str_or_build_locale(command.metadata.sub_group.name)
                 description, description_localizations = str_or_build_locale(
-                    unwrap(command.metadata.sub_group).description or "No Description"
+                    command.metadata.sub_group.description or "No Description"
                 )
 
                 sub_command_group = CommandOption(
@@ -233,7 +231,7 @@ class CommandHandler:
 
                 name, name_localizations = str_or_build_locale(command.metadata.app_command.name)
                 description, description_localizations = str_or_build_locale(
-                    unwrap(command.metadata.app_command.description)
+                    command.metadata.app_command.description or "No Description"
                 )
 
                 cast("list[CommandOption]", sub_command_group.options).append(
@@ -270,7 +268,7 @@ class CommandHandler:
                 if key not in built_commands:
                     built_commands[key] = AppCommand(
                         name=command.metadata.group.name,
-                        description=unwrap(command.metadata.group).description or "No Description",
+                        description=command.metadata.group.description or "No Description",
                         type=command.metadata.app_command.type,
                         guild_id=command.metadata.app_command.guild_id,
                         options=[],
@@ -283,7 +281,7 @@ class CommandHandler:
                 # lowest level.
                 name, name_localizations = str_or_build_locale(command.metadata.app_command.name)
                 description, description_localizations = str_or_build_locale(
-                    unwrap(command.metadata.app_command.description)
+                    command.metadata.app_command.description or "No Description"
                 )
 
                 cast("list[CommandOption]", built_commands[key].options).append(

--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -230,8 +230,9 @@ class CommandHandler:
                     children.append(sub_command_group)
 
                 name, name_localizations = str_or_build_locale(command.metadata.app_command.name)
+                assert command.metadata.app_command.description
                 description, description_localizations = str_or_build_locale(
-                    command.metadata.app_command.description or "No Description",
+                    command.metadata.app_command.description,
                 )
 
                 cast("list[CommandOption]", sub_command_group.options).append(
@@ -280,8 +281,9 @@ class CommandHandler:
                 # No checking has to be done before appending `command` since it is the
                 # lowest level.
                 name, name_localizations = str_or_build_locale(command.metadata.app_command.name)
+                assert command.metadata.app_command.description
                 description, description_localizations = str_or_build_locale(
-                    command.metadata.app_command.description or "No Description",
+                    command.metadata.app_command.description,
                 )
 
                 cast("list[CommandOption]", built_commands[key].options).append(

--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -34,8 +34,6 @@ if TYPE_CHECKING:
     from crescent.client import Client
     from crescent.typedefs import AutocompleteCallbackT, CommandCallbackT
 
-    T = TypeVar("T", bound="Callable[..., Awaitable[Any]]")
-
 _log = getLogger(__name__)
 
 

--- a/crescent/locale.py
+++ b/crescent/locale.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Mapping, Sequence
+from typing import TYPE_CHECKING
 
-__all__: Sequence[str] = ("LocaleBuilder", "str_or_build_locale")
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+__all__ = ("LocaleBuilder", "str_or_build_locale")
 
 
 class LocaleBuilder(ABC):
@@ -19,7 +22,7 @@ class LocaleBuilder(ABC):
         language codes to strings.
 
         [Discord API Docs Localization.](https://discord.com/developers/docs/interactions/application-commands#localization)
-        """  # noqa: E501
+        """
 
     @property
     @abstractmethod
@@ -30,5 +33,4 @@ class LocaleBuilder(ABC):
 def str_or_build_locale(string_or_locale: str | LocaleBuilder) -> tuple[str, Mapping[str, str]]:
     if isinstance(string_or_locale, LocaleBuilder):
         return (string_or_locale.fallback, string_or_locale.build())
-    else:
-        return (string_or_locale, {})
+    return (string_or_locale, {})

--- a/crescent/mentionable.py
+++ b/crescent/mentionable.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-
     from hikari import CommandInteraction, Role, User
 
 __all__ = ("Mentionable",)

--- a/crescent/mentionable.py
+++ b/crescent/mentionable.py
@@ -4,14 +4,13 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Sequence
 
     from hikari import CommandInteraction, Role, User
 
-__all__: Sequence[str] = ("Mentionable",)
+__all__ = ("Mentionable",)
 
 
-@dataclass
+@dataclass(slots=True)
 class Mentionable:
     """
     Represent's discord's mentionable type. A mentionable can be a User or Role.
@@ -28,8 +27,6 @@ class Mentionable:
             role = mentionable.unwrap_role()
     ```
     """
-
-    __slots__ = ("user", "role")
 
     user: User | None
     role: Role | None

--- a/crescent/plugin.py
+++ b/crescent/plugin.py
@@ -3,20 +3,20 @@ from __future__ import annotations
 from importlib import import_module, reload
 from logging import getLogger
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Generic, Literal, Sequence, TypeVar, cast, overload
-
-from hikari import Event
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast, overload
 
 from crescent.exceptions import PluginAlreadyLoadedError
 from crescent.hooks import add_hooks
-from crescent.internal.includable import Includable
-from crescent.typedefs import EventHookCallbackT
 
 if TYPE_CHECKING:
-    from crescent.client import Client, GatewayTraits, RESTTraits
-    from crescent.typedefs import CommandHookCallbackT, PluginCallbackT
 
-__all__: Sequence[str] = ("PluginManager", "Plugin")
+    from hikari import Event
+
+    from crescent.client import Client, GatewayTraits, RESTTraits
+    from crescent.internal.includable import Includable
+    from crescent.typedefs import CommandHookCallbackT, EventHookCallbackT, PluginCallbackT
+
+__all__ = ("Plugin", "PluginManager")
 
 
 T = TypeVar("T", bound="Includable[Any]")
@@ -242,13 +242,13 @@ class Plugin(Generic[BotT, ModelT]):
     def app(self) -> BotT:
         if not self._client:
             raise AttributeError("`Plugin.app` can not be accessed before the plugin is loaded.")
-        return cast(BotT, self._client.app)
+        return cast("BotT", self._client.app)
 
     @property
     def model(self) -> ModelT:
         if not self._client:
             raise AttributeError("`Plugin.model` can not be accessed before the plugin is loaded.")
-        return cast(ModelT, self._client.model)
+        return cast("ModelT", self._client.model)
 
     @property
     def client(self) -> Client:

--- a/crescent/plugin.py
+++ b/crescent/plugin.py
@@ -9,7 +9,6 @@ from crescent.exceptions import PluginAlreadyLoadedError
 from crescent.hooks import add_hooks
 
 if TYPE_CHECKING:
-
     from hikari import Event
 
     from crescent.client import Client, GatewayTraits, RESTTraits
@@ -46,21 +45,35 @@ class PluginManager:
 
     @overload
     def load(
-        self, path: str, *, strict: Literal[True], refresh: bool = ...
+        self,
+        path: str,
+        *,
+        strict: Literal[True],
+        refresh: bool = ...,
     ) -> Plugin[Any, Any]: ...
 
     @overload
     def load(
-        self, path: str, *, strict: Literal[False], refresh: bool = ...
+        self,
+        path: str,
+        *,
+        strict: Literal[False],
+        refresh: bool = ...,
     ) -> Plugin[Any, Any] | None: ...
 
     @overload
     def load(
-        self, path: str, refresh: bool = ..., strict: bool = ...
+        self,
+        path: str,
+        refresh: bool = ...,
+        strict: bool = ...,
     ) -> Plugin[Any, Any] | None: ...
 
     def load(
-        self, path: str, refresh: bool = False, strict: bool = True
+        self,
+        path: str,
+        refresh: bool = False,
+        strict: bool = True,
     ) -> Plugin[Any, Any] | None:
         """Load a plugin from the module path.
 
@@ -92,7 +105,10 @@ class PluginManager:
         return plugin
 
     def load_folder(
-        self, path: str, refresh: bool = False, strict: bool = True
+        self,
+        path: str,
+        refresh: bool = False,
+        strict: bool = True,
     ) -> list[Plugin[Any, Any]]:
         """Loads plugins from a folder.
 
@@ -135,7 +151,8 @@ class PluginManager:
 
         if not loaded_plugins:
             _LOG.warning(
-                "No plugins were loaded! Are you sure `%s` is the correct directory?", pathlib_path
+                "No plugins were loaded! Are you sure `%s` is the correct directory?",
+                pathlib_path,
             )
 
         return loaded_plugins
@@ -163,7 +180,7 @@ class PluginManager:
         if path in self.plugins and not refresh:
             raise PluginAlreadyLoadedError(
                 f"Plugin `{path}` is already loaded."
-                " Add the kwarg `refresh=True` to the function call if this is intended."
+                " Add the kwarg `refresh=True` to the function call if this is intended.",
             )
 
         self.plugins[path] = plugin
@@ -254,7 +271,7 @@ class Plugin(Generic[BotT, ModelT]):
     def client(self) -> Client:
         if not self._client:
             raise AttributeError(
-                "`Plugin.client` can not be accessed before the plugin is loaded."
+                "`Plugin.client` can not be accessed before the plugin is loaded.",
             )
         return self._client
 
@@ -290,24 +307,38 @@ class Plugin(Generic[BotT, ModelT]):
     @overload
     @classmethod
     def _from_module(
-        cls, path: str, *, strict: Literal[True], refresh: bool = ...
+        cls,
+        path: str,
+        *,
+        strict: Literal[True],
+        refresh: bool = ...,
     ) -> Plugin[BotT, ModelT]: ...
 
     @overload
     @classmethod
     def _from_module(
-        cls, path: str, *, strict: Literal[False], refresh: bool = ...
+        cls,
+        path: str,
+        *,
+        strict: Literal[False],
+        refresh: bool = ...,
     ) -> Plugin[BotT, ModelT] | None: ...
 
     @overload
     @classmethod
     def _from_module(
-        cls, path: str, refresh: bool = ..., strict: bool = ...
+        cls,
+        path: str,
+        refresh: bool = ...,
+        strict: bool = ...,
     ) -> Plugin[BotT, ModelT] | None: ...
 
     @classmethod
     def _from_module(
-        cls, path: str, refresh: bool = False, strict: bool = True
+        cls,
+        path: str,
+        refresh: bool = False,
+        strict: bool = True,
     ) -> Plugin[BotT, ModelT] | None:
         parents = path.split(".")
 
@@ -323,7 +354,7 @@ class Plugin(Generic[BotT, ModelT]):
             raise ValueError(
                 f"Plugin {path} has no `plugin` or `plugin` is not of type Plugin. "
                 "If you want to name your plugin something else, you have to add an "
-                "alias (plugin = YOUR_PLUGIN_NAME)."
+                "alias (plugin = YOUR_PLUGIN_NAME).",
             )
 
         return plugin

--- a/crescent/plugin.py
+++ b/crescent/plugin.py
@@ -65,6 +65,7 @@ class PluginManager:
     def load(
         self,
         path: str,
+        *,
         refresh: bool = ...,
         strict: bool = ...,
     ) -> Plugin[Any, Any] | None: ...
@@ -72,6 +73,7 @@ class PluginManager:
     def load(
         self,
         path: str,
+        *,
         refresh: bool = False,
         strict: bool = True,
     ) -> Plugin[Any, Any] | None:
@@ -107,6 +109,7 @@ class PluginManager:
     def load_folder(
         self,
         path: str,
+        *,
         refresh: bool = False,
         strict: bool = True,
     ) -> list[Plugin[Any, Any]]:
@@ -176,7 +179,13 @@ class PluginManager:
                 self.unload(plugin_path)
             raise e
 
-    def _add_plugin(self, path: str, plugin: Plugin[Any, Any], refresh: bool = False) -> None:
+    def _add_plugin(
+        self,
+        path: str,
+        plugin: Plugin[Any, Any],
+        *,
+        refresh: bool = False,
+    ) -> None:
         if path in self.plugins and not refresh:
             raise PluginAlreadyLoadedError(
                 f"Plugin `{path}` is already loaded."
@@ -329,6 +338,7 @@ class Plugin(Generic[BotT, ModelT]):
     def _from_module(
         cls,
         path: str,
+        *,
         refresh: bool = ...,
         strict: bool = ...,
     ) -> Plugin[BotT, ModelT] | None: ...
@@ -337,6 +347,7 @@ class Plugin(Generic[BotT, ModelT]):
     def _from_module(
         cls,
         path: str,
+        *,
         refresh: bool = False,
         strict: bool = True,
     ) -> Plugin[BotT, ModelT] | None:

--- a/crescent/ruff.toml
+++ b/crescent/ruff.toml
@@ -1,0 +1,27 @@
+extend = "../pyproject.toml"
+
+[lint]
+extend-select = [
+    # bugs/correctness (bugbear, unused args, builtin shadowing,
+    # async rules, security, blind excepts)
+    "B", "ARG", "A", "ASYNC", "S",
+    # readability/refactoring (simplicity, flake8-comp, pie, raise/return,
+    # slots, refurb)
+    "SIM", "C4", "PIE", "RSE", "RET", "SLOT", "FURB",
+    # style/formatting (isort, import conventions, tidy imports, pathlib,
+    # quotes, string concat, commas, naming, type-checking, annotations)
+    "I", "ICN", "TID", "PTH", "Q", "ISC", "COM", "N", "TC", "ANN",
+    # logging/project hygiene (logging, namespace packages, print/debugger,
+    # executable, pygrep hooks)
+    "G", "LOG", "INP", "T20", "T10", "EXE", "PGH",
+    # time/modernization (future annotations, datetime rules, 2020 checks,
+    # pyupgrade, flynt, performance)
+    "FA", "DTZ", "YTT", "UP", "FLY", "PERF",
+    # lib-specific (pytest)
+    "PT"
+]
+ignore = ["COM812", "ANN401"]
+
+[lint.per-file-ignores]
+"ext/locales/__init__.py" = ["N801", "N815"]
+"locale.py" = ["A005"]

--- a/crescent/ruff.toml
+++ b/crescent/ruff.toml
@@ -46,7 +46,7 @@ select = [
     # --- Best Practices & Clean Code ---
     "A",    # flake8-builtins
     "ARG",  # flake8-unused-arguments
-    #"FBT",  # flake8-boolean-trap
+    "FBT",  # flake8-boolean-trap
     #"EM",   # flake8-errmsg
     #"TRY",  # tryceratops
     #"SLF",  # flake8-self

--- a/crescent/ruff.toml
+++ b/crescent/ruff.toml
@@ -1,27 +1,101 @@
 extend = "../pyproject.toml"
 
 [lint]
-extend-select = [
-    # bugs/correctness (bugbear, unused args, builtin shadowing,
-    # async rules, security, blind excepts)
-    "B", "ARG", "A", "ASYNC", "S",
-    # readability/refactoring (simplicity, flake8-comp, pie, raise/return,
-    # slots, refurb)
-    "SIM", "C4", "PIE", "RSE", "RET", "SLOT", "FURB",
-    # style/formatting (isort, import conventions, tidy imports, pathlib,
-    # quotes, string concat, commas, naming, type-checking, annotations)
-    "I", "ICN", "TID", "PTH", "Q", "ISC", "COM", "N", "TC", "ANN",
-    # logging/project hygiene (logging, namespace packages, print/debugger,
-    # executable, pygrep hooks)
-    "G", "LOG", "INP", "T20", "T10", "EXE", "PGH",
-    # time/modernization (future annotations, datetime rules, 2020 checks,
-    # pyupgrade, flynt, performance)
-    "FA", "DTZ", "YTT", "UP", "FLY", "PERF",
-    # lib-specific (pytest)
-    "PT"
+select = [
+    # --- Correctness & Bug Prevention ---
+    "F",    # Pyflakes
+    "E",    # pycodestyle (errors)
+    "W",    # pycodestyle (warnings)
+    "B",    # flake8-bugbear
+    #"BLE",  # flake8-blind-except
+    #"PL",   # Pylint
+    "PGH",  # pygrep-hooks
+    "RSE",  # flake8-raise
+    "RET",  # flake8-return
+
+    # --- Security ---
+    #"S",    # flake8-bandit
+
+    # --- Style & Formatting ---
+    "N",    # pep8-naming
+    "Q",    # flake8-quotes
+    "COM",  # flake8-commas
+    "I",    # isort
+    #"D",    # pydocstyle
+    #"DOC",  # pydoclint
+
+    # --- Simplification & Modernization ---
+    "UP",   # pyupgrade
+    "SIM",  # flake8-simplify
+    "FURB", # refurb
+    "PIE",  # flake8-pie
+    "C4",   # flake8-comprehensions
+    "FLY",  # flynt
+    "ERA",  # eradicate
+
+    # --- Performance & Complexity ---
+    "PERF", # Perflint
+    #"C90",  # mccabe
+
+    # --- Type Annotations & Checking ---
+    "ANN",  # flake8-annotations
+    "TC",   # flake8-type-checking
+    "FA",   # flake8-future-annotations
+    "PYI",  # flake8-pyi
+
+    # --- Best Practices & Clean Code ---
+    "A",    # flake8-builtins
+    "ARG",  # flake8-unused-arguments
+    #"FBT",  # flake8-boolean-trap
+    #"EM",   # flake8-errmsg
+    #"TRY",  # tryceratops
+    #"SLF",  # flake8-self
+    "PTH",  # flake8-use-pathlib
+    "ISC",  # flake8-implicit-str-concat
+    "ICN",  # flake8-import-conventions
+    "TID",  # flake8-tidy-imports
+    "INP",  # flake8-no-pep420
+    "SLOT", # flake8-slots
+
+    # --- Logging ---
+    "LOG",  # flake8-logging
+    "G",    # flake8-logging-format
+
+    # --- Async ---
+    "ASYNC", # flake8-async
+
+    # --- Development Hygiene ---
+    "T10",  # flake8-debugger
+    "T20",  # flake8-print
+    #"FIX",  # flake8-fixme
+    #"TD",   # flake8-todos
+    "EXE",  # flake8-executable
+    "DTZ",  # flake8-datetimez
+    #"CPY",  # flake8-copyright
+
+    # --- Framework-Specific ---
+    #"AIR",  # Airflow
+    #"FAST", # FastAPI
+    #"DJ",   # flake8-django
+    #"PT",   # flake8-pytest-style
+    #"NPY",  # NumPy-specific rules
+    #"PD",   # pandas-vet
+
+    # --- Miscellaneous ---
+    "YTT",  # flake8-2020
+    "INT",  # flake8-gettext
+    "RUF",  # Ruff-specific rules
 ]
-ignore = ["COM812", "ANN401"]
+ignore = [
+    "ANN401", # we allow use of Any
+    "COM812", # conflicts with formatter
+]
 
 [lint.per-file-ignores]
-"ext/locales/__init__.py" = ["N801", "N815"]
-"locale.py" = ["A005"]
+"ext/locales/__init__.py" = [
+    "N801", # class
+    "N815", # mixed
+]
+"locale.py" = [
+    "A005", # stdlib
+]

--- a/crescent/ruff.toml
+++ b/crescent/ruff.toml
@@ -2,7 +2,7 @@ extend = "../pyproject.toml"
 
 [lint]
 select = [
-    # --- Correctness & Bug Prevention ---
+    # Correctness
     "F",    # Pyflakes
     "E",    # pycodestyle (errors)
     "W",    # pycodestyle (warnings)
@@ -13,10 +13,13 @@ select = [
     "RSE",  # flake8-raise
     "RET",  # flake8-return
 
-    # --- Security ---
+    # Specific pylint rules
+    "PLC0105", # type-name-incorrect-variance
+
+    # Security
     #"S",    # flake8-bandit
 
-    # --- Style & Formatting ---
+    # Style & formatting
     "N",    # pep8-naming
     "Q",    # flake8-quotes
     "COM",  # flake8-commas
@@ -24,7 +27,7 @@ select = [
     #"D",    # pydocstyle
     #"DOC",  # pydoclint
 
-    # --- Simplification & Modernization ---
+    # Simplification & modernization
     "UP",   # pyupgrade
     "SIM",  # flake8-simplify
     "FURB", # refurb
@@ -33,17 +36,17 @@ select = [
     "FLY",  # flynt
     "ERA",  # eradicate
 
-    # --- Performance & Complexity ---
+    # Performance & complexity
     "PERF", # Perflint
     #"C90",  # mccabe
 
-    # --- Type Annotations & Checking ---
+    # Type annotations & checking
     "ANN",  # flake8-annotations
     "TC",   # flake8-type-checking
     "FA",   # flake8-future-annotations
     "PYI",  # flake8-pyi
 
-    # --- Best Practices & Clean Code ---
+    # Best practices & clean code
     "A",    # flake8-builtins
     "ARG",  # flake8-unused-arguments
     "FBT",  # flake8-boolean-trap
@@ -57,14 +60,14 @@ select = [
     "INP",  # flake8-no-pep420
     "SLOT", # flake8-slots
 
-    # --- Logging ---
+    # Logging
     "LOG",  # flake8-logging
     "G",    # flake8-logging-format
 
     # --- Async ---
     "ASYNC", # flake8-async
 
-    # --- Development Hygiene ---
+    # Development hygiene
     "T10",  # flake8-debugger
     "T20",  # flake8-print
     #"FIX",  # flake8-fixme
@@ -73,7 +76,7 @@ select = [
     "DTZ",  # flake8-datetimez
     #"CPY",  # flake8-copyright
 
-    # --- Framework-Specific ---
+    # Framework-specific
     #"AIR",  # Airflow
     #"FAST", # FastAPI
     #"DJ",   # flake8-django
@@ -81,7 +84,7 @@ select = [
     #"NPY",  # NumPy-specific rules
     #"PD",   # pandas-vet
 
-    # --- Miscellaneous ---
+    # Miscellaneous
     "YTT",  # flake8-2020
     "INT",  # flake8-gettext
     "RUF",  # Ruff-specific rules

--- a/crescent/ruff.toml
+++ b/crescent/ruff.toml
@@ -88,7 +88,6 @@ select = [
 ]
 ignore = [
     "ANN401", # we allow use of Any
-    "COM812", # conflicts with formatter
 ]
 
 [lint.per-file-ignores]

--- a/crescent/typedefs.py
+++ b/crescent/typedefs.py
@@ -70,5 +70,6 @@ ErrorT = TypeVar("ErrorT", bound=Exception, contravariant=True)
 CommandErrorHandlerCallbackT = Callable[[ErrorT, Any], Awaitable[None]]
 EventErrorHandlerCallbackT = Callable[[ErrorT, Event], Awaitable[None]]
 AutocompleteErrorHandlerCallbackT = Callable[
-    [ErrorT, Any, AutocompleteInteractionOption], Awaitable[None]
+    [ErrorT, Any, AutocompleteInteractionOption],
+    Awaitable[None],
 ]

--- a/crescent/typedefs.py
+++ b/crescent/typedefs.py
@@ -65,11 +65,11 @@ class ClassCommandProto(Protocol):
     async def callback(self, ctx: Any) -> Any: ...
 
 
-ErrorT = TypeVar("ErrorT", bound=Exception, contravariant=True)
+ErrorT_contra = TypeVar("ErrorT_contra", bound=Exception, contravariant=True)
 
-CommandErrorHandlerCallbackT = Callable[[ErrorT, Any], Awaitable[None]]
-EventErrorHandlerCallbackT = Callable[[ErrorT, Event], Awaitable[None]]
+CommandErrorHandlerCallbackT = Callable[[ErrorT_contra, Any], Awaitable[None]]
+EventErrorHandlerCallbackT = Callable[[ErrorT_contra, Event], Awaitable[None]]
 AutocompleteErrorHandlerCallbackT = Callable[
-    [ErrorT, Any, AutocompleteInteractionOption],
+    [ErrorT_contra, Any, AutocompleteInteractionOption],
     Awaitable[None],
 ]

--- a/crescent/typedefs.py
+++ b/crescent/typedefs.py
@@ -1,15 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
-    Awaitable,
-    Callable,
-    Dict,
     Optional,
     Protocol,
-    Sequence,
-    Tuple,
     TypeVar,
     Union,
 )
@@ -29,18 +25,18 @@ if TYPE_CHECKING:
     from crescent.hooks import HookResult
     from crescent.mentionable import Mentionable
 
-__all__: Sequence[str] = (
-    "CommandCallbackT",
-    "OptionTypesT",
-    "UserCommandCallbackT",
-    "MessageCommandCallbackT",
-    "CommandOptionsT",
-    "ClassCommandProto",
-    "CommandErrorHandlerCallbackT",
+__all__ = (
     "AutocompleteCallbackT",
     "AutocompleteValueT",
+    "ClassCommandProto",
+    "CommandCallbackT",
+    "CommandErrorHandlerCallbackT",
     "CommandHookCallbackT",
+    "CommandOptionsT",
     "EventHookCallbackT",
+    "MessageCommandCallbackT",
+    "OptionTypesT",
+    "UserCommandCallbackT",
 )
 
 CommandCallbackT = Callable[["Context"], Awaitable[Any]]
@@ -48,11 +44,11 @@ UserCommandCallbackT = Callable[["Context", User], Awaitable[None]]
 MessageCommandCallbackT = Callable[["Context", Message], Awaitable[None]]
 
 OptionTypesT = Union[str, bool, int, float, PartialChannel, Role, User, "Mentionable", Attachment]
-CommandOptionsT = Dict[str, Union[OptionTypesT, User, Message]]
+CommandOptionsT = dict[str, OptionTypesT | User | Message]
 AutocompleteValueT = TypeVar("AutocompleteValueT", str, int, float)
 AutocompleteCallbackT = Callable[
     ["AutocompleteContext", AutocompleteInteractionOption],
-    Awaitable[Sequence[Tuple[str, AutocompleteValueT]]],
+    Awaitable[Sequence[tuple[str, AutocompleteValueT]]],
 ]
 
 CommandHookCallbackT = Callable[["Context"], Awaitable[Optional["HookResult"]]]

--- a/crescent/utils/__init__.py
+++ b/crescent/utils/__init__.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
-from typing import Sequence
+from crescent.utils.any_issubclass import any_issubclass
+from crescent.utils.gather_iter import gather_iter
+from crescent.utils.hooks import add_hooks
+from crescent.utils.options import map_or, unwrap
+from crescent.utils.tasks import create_task
 
-from crescent.utils.any_issubclass import *
-from crescent.utils.gather_iter import *
-from crescent.utils.hooks import *
-from crescent.utils.options import *
-from crescent.utils.tasks import *
-
-__all__: Sequence[str] = (
+__all__ = (
     "add_hooks",
     "any_issubclass",
-    "gather_iter",
-    "unwrap",
-    "map_or",
     "create_task",
+    "gather_iter",
+    "map_or",
+    "unwrap",
 )

--- a/crescent/utils/any_issubclass.py
+++ b/crescent/utils/any_issubclass.py
@@ -1,7 +1,9 @@
-from inspect import isclass
-from typing import Any, Sequence
+from __future__ import annotations
 
-__all__: Sequence[str] = ("any_issubclass",)
+from inspect import isclass
+from typing import Any
+
+__all__ = ("any_issubclass",)
 
 
 def any_issubclass(obj: Any, cls: type) -> bool:

--- a/crescent/utils/gather_iter.py
+++ b/crescent/utils/gather_iter.py
@@ -1,7 +1,12 @@
-from asyncio import gather
-from typing import Awaitable, Iterable, Sequence, TypeVar
+from __future__ import annotations
 
-__all__: Sequence[str] = ("gather_iter",)
+from asyncio import gather
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Iterable
+
+__all__ = ("gather_iter",)
 
 
 T = TypeVar("T")

--- a/crescent/utils/hooks.py
+++ b/crescent/utils/hooks.py
@@ -11,7 +11,12 @@ T = TypeVar("T")
 
 
 def add_hooks(
-    hooks: list[T], after_hooks: list[T], hooks_to_add: Sequence[T], *, prepend: bool, after: bool
+    hooks: list[T],
+    after_hooks: list[T],
+    hooks_to_add: Sequence[T],
+    *,
+    prepend: bool,
+    after: bool,
 ) -> None:
     def extend_or_prepend(list_to_edit: list[T]) -> None:
         if prepend:

--- a/crescent/utils/hooks.py
+++ b/crescent/utils/hooks.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
-from typing import Sequence, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
-__all__: Sequence[str] = ("add_hooks",)
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+__all__ = ("add_hooks",)
 
 T = TypeVar("T")
 

--- a/crescent/utils/options.py
+++ b/crescent/utils/options.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from typing import Callable, Sequence, TypeVar, overload
+from typing import TYPE_CHECKING, TypeVar, overload
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 T = TypeVar("T")
 U = TypeVar("U")
 V = TypeVar("V")
 
-__all__: Sequence[str] = ("unwrap", "map_or")
+__all__ = ("map_or", "unwrap")
 
 
 def unwrap(o: T | None) -> T:

--- a/crescent/utils/tasks.py
+++ b/crescent/utils/tasks.py
@@ -2,17 +2,20 @@ from __future__ import annotations
 
 from asyncio import Task
 from asyncio import create_task as _create_task
-from typing import Any, Awaitable, Coroutine, Sequence, Set, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
-__all__: Sequence[str] = ("create_task",)
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Coroutine
+
+__all__ = ("create_task",)
 
 T = TypeVar("T")
 
-_background_tasks: Set[Any] = set()
+_background_tasks: set[Any] = set()
 
 
 def create_task(_task: Coroutine[Any, Any, T] | Awaitable[T]) -> Task[T]:
-    task: Task[Any] = _create_task(_task)  # type: ignore
+    task: Task[Any] = _create_task(_task)  # type: ignore[arg-type]
 
     _background_tasks.add(task)
     task.add_done_callback(_background_tasks.remove)

--- a/examples/basic/basic.py
+++ b/examples/basic/basic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hikari
 
 import crescent

--- a/examples/basic/basic.py
+++ b/examples/basic/basic.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+import random
+
 import hikari
 
 import crescent
 from crescent import options
-
-import random
 
 # The bot object can be any impl that implements `hikari.traits.RESTAware` and
 # `hikari.traits.EventManagerAware`. For most users this will be `hikari.GatewayBot`.

--- a/examples/error_handling/basic.py
+++ b/examples/error_handling/basic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hikari
+
 import crescent
 from crescent import options
 

--- a/examples/ext/cooldowns/basic.py
+++ b/examples/ext/cooldowns/basic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 
 import hikari

--- a/examples/ext/locales/basic.py
+++ b/examples/ext/locales/basic.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 #  pyright: reportMissingTypeStubs=false, reportUnknownMemberType=false, reportUnknownVariableType=false
-
 # Crescent provides 2 implementations for `crescent.LocaleBuilder`
-
 import hikari
 
 import crescent

--- a/examples/ext/locales/basic.py
+++ b/examples/ext/locales/basic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 #  pyright: reportMissingTypeStubs=false, reportUnknownMemberType=false, reportUnknownVariableType=false
 
 # Crescent provides 2 implementations for `crescent.LocaleBuilder`

--- a/examples/ext/tasks/basic.py
+++ b/examples/ext/tasks/basic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 
 import hikari

--- a/examples/hooks/after_hooks.py
+++ b/examples/hooks/after_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hikari
 
 import crescent

--- a/examples/hooks/group_hooks.py
+++ b/examples/hooks/group_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hikari
 
 import crescent

--- a/examples/hooks/hooks.py
+++ b/examples/hooks/hooks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hikari
 
 import crescent

--- a/examples/hooks/plugin_hooks.py
+++ b/examples/hooks/plugin_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hikari
 
 import crescent

--- a/examples/locales/basic.py
+++ b/examples/locales/basic.py
@@ -42,9 +42,9 @@ class Command:
     # "en-option-name" and "en-option-description" will be used when the user is
     # using the `en-US` locale. Otherwise "option-name" and "option-description"
     # will be visible.
-    word = options.string(
-        Locale("option-description", en_US="en-option-description")
-    ).name(Locale("option-name", en_US="en-option-name"))
+    word = options.string(Locale("option-description", en_US="en-option-description")).name(
+        Locale("option-name", en_US="en-option-name")
+    )
 
     async def callback(self, ctx: crescent.Context) -> None:
         # The locale of the user who ran the command can be viewed with `Context.locale`

--- a/examples/plugins/example.py
+++ b/examples/plugins/example.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 
 import hikari

--- a/examples/plugins/folder/another_plugin.py
+++ b/examples/plugins/folder/another_plugin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hikari
 
 import crescent

--- a/examples/plugins/plugin.py
+++ b/examples/plugins/plugin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing
 
 import hikari

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ reportPrivateUsage = false
 reportIncompatibleMethodOverride = false
 
 [tool.ruff]
-lint.select = ["E", "W", "F", "RUF", "I"]
+lint.select = ["E", "W", "F", "RUF", "I", "PT"]
 line-length = 99
 
 [tool.ruff.lint.pyflakes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ reportPrivateUsage = false
 reportIncompatibleMethodOverride = false
 
 [tool.ruff]
-lint.select = ["E", "W", "F", "RUF"]
+lint.select = ["E", "W", "F", "RUF", "I"]
 line-length = 99
 
 [tool.ruff.lint.pyflakes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,18 +89,7 @@ reportWildcardImportFromLibrary = false
 
 [tool.ruff]
 target-version = "py310"
-lint.ignore = [
-  # Allow * imports to be used in the module level
-  "F403",
-  "F405",
-]
-lint.select = [
-  # Pyflakes
-  "E",
-  "F",
-  # Dangling Tasks
-  "RUF006",
-]
+lint.select = ["E", "W", "F", "RUF"]
 line-length = 99
 
 [tool.ruff.lint.pyflakes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ warn_unused_configs = true
 warn_return_any = true
 warn_redundant_casts = true
 namespace_packages = true
-warn_unused_ignores = false
+warn_unused_ignores = true
 
 [tool.pyright]
 include = ["crescent", "examples"]
@@ -85,7 +85,6 @@ typeCheckingMode = "strict"
 reportPrivateUsage = false
 reportImportCycles = false
 reportIncompatibleMethodOverride = false
-reportWildcardImportFromLibrary = false
 
 [tool.ruff]
 target-version = "py310"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,11 +71,6 @@ build-backend = "uv_build"
 [tool.mypy]
 python_version = "3.10"
 strict = true
-warn_unused_configs = true
-warn_return_any = true
-warn_redundant_casts = true
-namespace_packages = true
-warn_unused_ignores = true
 
 [tool.pyright]
 include = ["crescent", "examples"]
@@ -83,11 +78,9 @@ exclude = ["tests"]
 pythonVersion = "3.10"
 typeCheckingMode = "strict"
 reportPrivateUsage = false
-reportImportCycles = false
 reportIncompatibleMethodOverride = false
 
 [tool.ruff]
-target-version = "py310"
 lint.select = ["E", "W", "F", "RUF"]
 line-length = 99
 
@@ -95,6 +88,3 @@ line-length = 99
 extend-generics = [
     "crescent.Plugin"
 ]
-
-[tool.pytest.ini_options]
-asyncio_mode = 'strict'

--- a/tests/crescent/commands/test_build.py
+++ b/tests/crescent/commands/test_build.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from hikari import CommandType, Permissions
 from hikari.impl.entity_factory import EntityFactoryImpl
 

--- a/tests/crescent/commands/test_command_function.py
+++ b/tests/crescent/commands/test_command_function.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from types import FunctionType
 
 from hikari import UNDEFINED, CommandType, Message, User

--- a/tests/crescent/commands/test_defaults.py
+++ b/tests/crescent/commands/test_defaults.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from hikari import UNDEFINED, Message, Permissions, User
 
 from crescent import Context, command, message_command, user_command

--- a/tests/crescent/commands/test_option_types.py
+++ b/tests/crescent/commands/test_option_types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from hikari import ChannelType, OptionType
 
 from crescent import command, options

--- a/tests/crescent/commands/test_permissions.py
+++ b/tests/crescent/commands/test_permissions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import pytest
 from hikari import PermissionOverwrite
-from pytest import raises
 
 from crescent import Context, Group, PermissionsError, command
 
@@ -9,7 +9,7 @@ from crescent import Context, Group, PermissionsError, command
 def test_no_perms_in_subcommand_group():
     group = Group("abcd")
 
-    with raises(PermissionsError):
+    with pytest.raises(PermissionsError):
 
         @group.child
         @command(default_member_permissions=PermissionOverwrite(id=0, type=0))
@@ -24,7 +24,7 @@ def test_no_perms_in_subcommand_subgroup():
     group = Group("abcd")
     sub_group = group.sub_group("abcd")
 
-    with raises(PermissionsError):
+    with pytest.raises(PermissionsError):
 
         @sub_group.child
         @command(default_member_permissions=PermissionOverwrite(id=0, type=0))

--- a/tests/crescent/commands/test_permissions.py
+++ b/tests/crescent/commands/test_permissions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from hikari import PermissionOverwrite
 from pytest import raises
 

--- a/tests/crescent/ctx/test_autocomplete_ctx.py
+++ b/tests/crescent/ctx/test_autocomplete_ctx.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from copy import copy
 from unittest.mock import AsyncMock, Mock
 
+import pytest
 from hikari import CommandInteractionOption, InteractionType, OptionType
 from hikari.impl import CacheImpl, RESTClientImpl
-from pytest import mark
 
 from crescent import AutocompleteContext
 from crescent.mentionable import Mentionable
@@ -66,7 +66,7 @@ guild_ctx.interaction.guild_id = 1234
 guild_ctx.interaction.options = options_with_role
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_fetch_options_not_cached():
     fetch_member_mock = AsyncMock(return_value="member")
     fetch_user_mock = AsyncMock(return_value="user")
@@ -105,7 +105,7 @@ async def test_fetch_options_not_cached():
     }
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_fetch_options_guild_not_cached():
     fetch_member_mock = AsyncMock(return_value="member")
     fetch_user_mock = AsyncMock(return_value="user")
@@ -155,7 +155,7 @@ async def test_fetch_options_guild_not_cached():
     }
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_fetch_options_cached():
     get_member_mock = Mock(return_value="member")
     get_user_mock = Mock(return_value="user")
@@ -180,7 +180,7 @@ async def test_fetch_options_cached():
     }
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_fetch_options_guild_cached():
     role_mock = Mock()
     role_mock.id = 12345

--- a/tests/crescent/ctx/test_autocomplete_ctx.py
+++ b/tests/crescent/ctx/test_autocomplete_ctx.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from copy import copy
 from unittest.mock import AsyncMock, Mock
 

--- a/tests/crescent/ctx/test_ctx.py
+++ b/tests/crescent/ctx/test_ctx.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from crescent.context import InteractionContext
 
 

--- a/tests/crescent/hooks/test_hook_order.py
+++ b/tests/crescent/hooks/test_hook_order.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from types import MethodType
 from typing import TYPE_CHECKING, Any
 
-from crescent import Group, Plugin, command, hook, event
 from hikari import Event
+
+from crescent import Group, Plugin, command, event, hook
 from tests.utils import MockClient
 
 

--- a/tests/crescent/internal/test_autocomplete_resp.py
+++ b/tests/crescent/internal/test_autocomplete_resp.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from hikari import AutocompleteInteractionOption, OptionType
 from pytest import mark
 

--- a/tests/crescent/internal/test_autocomplete_resp.py
+++ b/tests/crescent/internal/test_autocomplete_resp.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
+import pytest
 from hikari import AutocompleteInteractionOption, OptionType
-from pytest import mark
 
 from crescent.internal.handle_resp import _get_option_recursive
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 class TestAutocompleteResp:
     async def test_top_level_command(self):
         options = [

--- a/tests/crescent/internal/test_compare_commands.py
+++ b/tests/crescent/internal/test_compare_commands.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import Mock
 
 from crescent.internal.app_command import AppCommand

--- a/tests/crescent/internal/test_compare_commands.py
+++ b/tests/crescent/internal/test_compare_commands.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from unittest.mock import Mock
 
-from crescent.internal.app_command import AppCommand
-
 from hikari import (
     ApplicationIntegrationType,
     PartialCommand,
@@ -11,6 +9,7 @@ from hikari import (
     SlashCommand,
 )
 
+from crescent.internal.app_command import AppCommand
 
 DEFAULT_CONTEXT = ()
 DEFAULT_INT = (ApplicationIntegrationType.GUILD_INSTALL,)

--- a/tests/crescent/internal/test_handle_resp.py
+++ b/tests/crescent/internal/test_handle_resp.py
@@ -20,8 +20,8 @@ from hikari import (
 from hikari.impl import RESTClientImpl
 from pytest import mark
 
-from crescent import Context, catch_autocomplete, catch_command, command, hook
 import crescent
+from crescent import Context, catch_autocomplete, catch_command, command, hook
 from crescent.exceptions import ConverterExceptions
 from crescent.internal.handle_resp import handle_resp
 from tests.utils import MockClient, MockRESTClient

--- a/tests/crescent/internal/test_handle_resp.py
+++ b/tests/crescent/internal/test_handle_resp.py
@@ -4,6 +4,7 @@ from asyncio import get_event_loop
 from typing import List, cast
 from unittest.mock import AsyncMock, Mock
 
+import pytest
 from hikari import (
     ApplicationContextType,
     AutocompleteInteraction,
@@ -18,7 +19,6 @@ from hikari import (
     OptionType,
 )
 from hikari.impl import RESTClientImpl
-from pytest import mark
 
 import crescent
 from crescent import Context, catch_autocomplete, catch_command, command, hook
@@ -113,7 +113,7 @@ def MockAutocompleteEvent(name, option_name, client):
     )
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_converter_ok() -> None:
     client = MockClient()
 
@@ -133,7 +133,7 @@ async def test_converter_ok() -> None:
     assert arg_val == 1
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_converter_error() -> None:
     client = MockClient()
 
@@ -169,7 +169,7 @@ async def test_converter_error() -> None:
     assert meta.command is test_command
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_handle_resp_slash_function():
     client = MockClient()
 
@@ -186,7 +186,7 @@ async def test_handle_resp_slash_function():
     assert command_was_run
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_handle_resp_slash_class():
     client = MockClient()
 
@@ -204,7 +204,7 @@ async def test_handle_resp_slash_class():
     assert command_was_run
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_hooks():
     client = MockClient()
     command_was_run = False
@@ -240,7 +240,7 @@ async def test_hooks():
     assert command_was_run
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_handle_command_error():
     client = MockClient()
     command_was_run = False
@@ -266,7 +266,7 @@ async def test_handle_command_error():
     assert command_was_run
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_unhandled_command_error():
     client = MockClient()
     command_was_run = False
@@ -291,7 +291,7 @@ async def test_unhandled_command_error():
     assert command_was_run
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_handle_autocomplete_error():
     client = MockClient()
     command_was_run = False
@@ -334,7 +334,7 @@ async def test_handle_autocomplete_error():
     assert not command_was_run
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_unhandled_autocomplete_error():
     client = MockClient()
     command_was_run = False
@@ -376,7 +376,7 @@ async def test_unhandled_autocomplete_error():
     assert not command_was_run
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_rest_bot_command():
     client = MockRESTClient()
 
@@ -405,7 +405,7 @@ async def test_rest_bot_command():
     assert command_was_run
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_rest_future_is_set():
     client = MockRESTClient()
 

--- a/tests/crescent/internal/test_handle_resp.py
+++ b/tests/crescent/internal/test_handle_resp.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from asyncio import get_event_loop
 from typing import List, cast
 from unittest.mock import AsyncMock, Mock

--- a/tests/crescent/internal/test_registry.py
+++ b/tests/crescent/internal/test_registry.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict
 from unittest.mock import AsyncMock, MagicMock
 

--- a/tests/crescent/internal/test_registry.py
+++ b/tests/crescent/internal/test_registry.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from collections import defaultdict
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from hikari import Message, User
 from hikari.impl import CacheImpl, RESTClientImpl
-from pytest import fixture, mark
 
 from crescent import Context, command
 from crescent import message_command as _message_command
@@ -16,7 +16,7 @@ GUILD_ID = 123456789
 
 
 class TestRegistry:
-    @fixture(autouse=True)
+    @pytest.fixture(autouse=True)
     def mock_send(self):
         self.posted_commands = defaultdict(list)
 
@@ -30,7 +30,7 @@ class TestRegistry:
 
         CacheImpl.get_guilds_view = MagicMock(return_value={0: GUILD_ID})
 
-    @mark.asyncio
+    @pytest.mark.asyncio
     async def test_post_commands(self):
         client = MockClient(default_guild=GUILD_ID)
 

--- a/tests/crescent/plugins/hook_plugin.py
+++ b/tests/crescent/plugins/hook_plugin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import crescent
 
 

--- a/tests/crescent/plugins/plugin.py
+++ b/tests/crescent/plugins/plugin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # This plugin is loaded by the `test_plugins.py` tests
 
 from hikari import MessageCreateEvent

--- a/tests/crescent/plugins/plugin.py
+++ b/tests/crescent/plugins/plugin.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 # This plugin is loaded by the `test_plugins.py` tests
-
 from hikari import MessageCreateEvent
 
 from crescent import Context, Plugin, catch_command, command, event

--- a/tests/crescent/plugins/plugin_folder/__init__.py
+++ b/tests/crescent/plugins/plugin_folder/__init__.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 # NOTE: This file is not required. It is here to test that files starting with _ are
 # skipped properly.

--- a/tests/crescent/plugins/plugin_folder/plugin.py
+++ b/tests/crescent/plugins/plugin_folder/plugin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from crescent import Plugin
 
 plugin = Plugin()

--- a/tests/crescent/plugins/plugin_folder/plugin_subfolder/plugin.py
+++ b/tests/crescent/plugins/plugin_folder/plugin_subfolder/plugin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from crescent import Plugin
 
 plugin = Plugin()

--- a/tests/crescent/plugins/plugin_folder_not_strict/plugin.py
+++ b/tests/crescent/plugins/plugin_folder_not_strict/plugin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from crescent import Plugin
 
 plugin = Plugin()

--- a/tests/crescent/plugins/test_plugins.py
+++ b/tests/crescent/plugins/test_plugins.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import pytest
 from hikari import MessageCreateEvent
-from pytest import LogCaptureFixture, raises
 
 from crescent.exceptions import PluginAlreadyLoadedError
 from tests.crescent.plugins.plugin import (
@@ -34,7 +34,7 @@ class TestPlugins:
     def test_load_not_plugin(self):
         client = MockClient()
 
-        with raises(ValueError):
+        with pytest.raises(ValueError, match=r"has no `plugin`"):
             client.plugins.load("tests.crescent.plugins.not_plugin")
 
         plugin = client.plugins.load("tests.crescent.plugins.not_plugin", strict=False)
@@ -92,7 +92,7 @@ class TestPlugins:
         assert orig is orig2
         assert orig is not new
 
-    def test_load_folder(self, caplog: LogCaptureFixture):
+    def test_load_folder(self, caplog: pytest.LogCaptureFixture):
         client = MockClient()
 
         plugins = client.plugins.load_folder("tests.crescent.plugins.plugin_folder")
@@ -115,7 +115,7 @@ class TestPlugins:
 
         client.plugins.load_folder("tests.crescent.plugins.plugin_folder")
 
-        with raises(PluginAlreadyLoadedError):
+        with pytest.raises(PluginAlreadyLoadedError):
             client.plugins.load_folder("tests.crescent.plugins.plugin_folder", refresh=False)
 
         client.plugins.load_folder("tests.crescent.plugins.plugin_folder", refresh=True)
@@ -123,7 +123,7 @@ class TestPlugins:
     def test_load_folder_with_not_plugins(self):
         client = MockClient()
 
-        with raises(ValueError):
+        with pytest.raises(ValueError, match=r"has no `plugin`"):
             client.plugins.load_folder("tests.crescent.plugins.plugin_folder_not_strict")
 
         # Plugins should be empty after loading fails
@@ -137,7 +137,7 @@ class TestPlugins:
 
         assert arrays_contain_same_elements([plugin], plugins)
 
-    def test_load_dir_not_exists(self, caplog: LogCaptureFixture):
+    def test_load_dir_not_exists(self, caplog: pytest.LogCaptureFixture):
         client = MockClient()
 
         client.plugins.load_folder("does.not.exist")
@@ -171,7 +171,7 @@ class TestPlugins:
 
         client.plugins.load("tests.crescent.plugins.plugin")
 
-        with raises(PluginAlreadyLoadedError):
+        with pytest.raises(PluginAlreadyLoadedError):
             client.plugins.load("tests.crescent.plugins.plugin")
 
     def test_client_loaded(self):
@@ -187,7 +187,7 @@ class TestPlugins:
         plugin = client.plugins.load("tests.crescent.plugins.plugin")
         client.plugins.unload("tests.crescent.plugins.plugin")
 
-        with raises(AttributeError):
+        with pytest.raises(AttributeError):
             plugin.app
 
     def test_model(self):

--- a/tests/crescent/test_error_handling.py
+++ b/tests/crescent/test_error_handling.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hikari
 
 import crescent

--- a/tests/crescent/test_locale.py
+++ b/tests/crescent/test_locale.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from crescent.locale import str_or_build_locale
 from tests.utils import Locale
 

--- a/tests/crescent/utils/test_any_issubclass.py
+++ b/tests/crescent/utils/test_any_issubclass.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from crescent.utils import any_issubclass
 
 

--- a/tests/test_bot/test_bot.py
+++ b/tests/test_bot/test_bot.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import os
 from datetime import datetime

--- a/tests/test_bot/test_plugin.py
+++ b/tests/test_bot/test_plugin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from hikari import GatewayBot
 import crescent
 

--- a/tests/test_bot/test_plugin.py
+++ b/tests/test_bot/test_plugin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from hikari import GatewayBot
+
 import crescent
 
 

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,13 +1,13 @@
-from typing import Sequence
+from __future__ import annotations
 
 from tests.utils.arrays import arrays_contain_same_elements
 from tests.utils.locale import Locale
 from tests.utils.mock_client import MockBot, MockClient, MockRESTClient
 
-__all__: Sequence[str] = (
+__all__ = (
+    "Locale",
     "MockBot",
     "MockClient",
     "MockRESTClient",
     "arrays_contain_same_elements",
-    "Locale",
 )

--- a/tests/utils/arrays.py
+++ b/tests/utils/arrays.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import Any, Sequence
+from typing import Any
 
-__all__: Sequence[str] = ("arrays_contain_same_elements",)
+__all__ = ("arrays_contain_same_elements",)
 
 
 def arrays_contain_same_elements(arr1: list[Any], arr2: list[Any]) -> bool:

--- a/tests/utils/locale.py
+++ b/tests/utils/locale.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Sequence
 
 from crescent import LocaleBuilder
 
-__all__: Sequence[str] = ("Locale",)
+__all__ = ("Locale",)
 
 
 @dataclass

--- a/tests/utils/mock_client.py
+++ b/tests/utils/mock_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from hikari import GatewayBot, Snowflake, StartedEvent, RESTBot
 
 from crescent import Client

--- a/tests/utils/mock_client.py
+++ b/tests/utils/mock_client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from hikari import GatewayBot, Snowflake, StartedEvent, RESTBot
+from typing import Any
+
+from hikari import GatewayBot, RESTBot, Snowflake, StartedEvent
 
 from crescent import Client
-from typing import Any
 from crescent.internal.registry import CommandHandler
 
 


### PR DESCRIPTION
Breaking changes:
- Context.defer(ephemeral=...) is keyword-only
- Context.respond_with_builder(ensure_message=...) is keyword-only
- @cronjob(on_startup=...) is keyword-only
- EventMeta.add_hooks(prepend=...) is keyword-only
- PluginManager.load(_folder)(refresh=..., strict=...) are keyword-only